### PR TITLE
AsyncWriteEngine.commit() hangs when writerThread dies

### DIFF
--- a/src/main/java/org/mapdb/AsyncWriteEngine.java
+++ b/src/main/java/org/mapdb/AsyncWriteEngine.java
@@ -258,7 +258,10 @@ public class AsyncWriteEngine extends EngineWrapper implements Engine {
         }
         commitLock.writeLock().lock();
         try{
-            while(!items.isEmpty()) LockSupport.parkNanos(100);
+            while(!items.isEmpty()) {
+                checkState();
+                LockSupport.parkNanos(100);
+            }
 
             super.commit();
         }finally {

--- a/src/test/java/org/mapdb/Issue78Test.java
+++ b/src/test/java/org/mapdb/Issue78Test.java
@@ -1,0 +1,32 @@
+package org.mapdb;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * https://github.com/jankotek/MapDB/issues/78
+ *
+ * @author Nandor Kracser
+ */
+public class Issue78Test {
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test(expected = RuntimeException.class, timeout = 1000)
+    public void testIssue() {
+        DB db = DBMaker.newTempFileDB().make();
+        HTreeMap<String, NotSerializable> usersMap = db.getHashMap("values");
+        usersMap.put("thisKillsTheAsyncWriteThread", new NotSerializable());
+        db.commit();
+    }
+
+    class NotSerializable {
+    }
+}


### PR DESCRIPTION
By mistake I wanted to insert a non-Serializable object into the Db (kills the writerThread) and call commit right after that but my program hung. This was caused by the loop in AsyncWriteEngine.commit(). This loop should check the writerThread's state in every iteration. Fix included with test.
