### PR TITLE
Fixing Queue.clear() method

### DIFF
--- a/src/main/java/org/mapdb/Queues.java
+++ b/src/main/java/org/mapdb/Queues.java
@@ -1,7 +1,5 @@
 package org.mapdb;
 
-
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -12,7 +10,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Various queues algorithms
+ * Various queue algorithms
  */
 public final class Queues {
 
@@ -106,7 +104,7 @@ public final class Queues {
         @Override
         public void clear() {
             while(!isEmpty())
-                remove();
+                poll();
         }
 
 
@@ -123,7 +121,6 @@ public final class Queues {
             E ret = peek();
             if(ret == null) throw new NoSuchElementException();
             return ret;
-
         }
 
 
@@ -131,7 +128,6 @@ public final class Queues {
         public boolean offer(E e) {
             return add(e);
         }
-
 
 
         @Override
@@ -202,7 +198,6 @@ public final class Queues {
 
         protected final boolean useLocks;
         protected final Locks.RecidLocks locks;
-
 
 
         public Stack(Engine engine,  Serializer<E> serializer, long headerRecid, boolean useLocks) {
@@ -327,12 +322,7 @@ public final class Queues {
             size = new Atomic.Long(engine,sizeRecid);
         }
 
-
         @Override
-        public boolean isEmpty() {
-            return head.get() == 0;
-        }
-
         public boolean add(E item){
             final long nextTail = engine.put((Node<E>)Node.EMPTY, nodeSerializer);
             Node<E> n = new Node<E>(nextTail, item);
@@ -346,6 +336,7 @@ public final class Queues {
             return true;
         }
 
+        @Override
         public E poll(){
             while(true){
                 long head2 = head.get();
@@ -471,6 +462,19 @@ public final class Queues {
         }
 
         @Override
+        public void clear() {
+            // praise locking
+            lock.lock();
+            try {
+                for (int i = 0; i < size; i++) {
+                    poll();
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        @Override
         public E poll() {
             lock.lock();
             try{
@@ -567,6 +571,5 @@ public final class Queues {
         CircularQueueRoot root = engine.get(rootRecid, new CircularQueueRootSerializer(serializerSerializer));
         return new CircularQueue<E>(engine, root.serializer, root.headerRecid, root.headerInsertRecid,root.sizeRecid);
     }
-
 
 }


### PR DESCRIPTION
It threw a NoSuchElementException when deleting the last element in the Queue. In case of CircularQueue the method is overridden to make it faster.
