### PR TITLE
Fix DeadLock in loading the SerializerBase Class

### DIFF
--- a/src/main/java/org/mapdb/SerializerBase.java
+++ b/src/main/java/org/mapdb/SerializerBase.java
@@ -33,20 +33,11 @@ import static org.mapdb.SerializationHeader.*;
 public class SerializerBase implements Serializer{
 
 
-    static final Set knownSerializable = new HashSet(Arrays.asList(
-            BTreeKeySerializer.STRING,
-            BTreeKeySerializer.ZERO_OR_POSITIVE_LONG,
-            BTreeKeySerializer.ZERO_OR_POSITIVE_INT,
 
-            Utils.COMPARABLE_COMPARATOR, Utils.COMPARABLE_COMPARATOR_WITH_NULLS,
-
-            Serializer.STRING_SERIALIZER, Serializer.LONG_SERIALIZER, Serializer.INTEGER_SERIALIZER,
-            Serializer.EMPTY_SERIALIZER, Serializer.BASIC_SERIALIZER, Serializer.CRC32_CHECKSUM
-    ));
 
     public static void assertSerializable(Object o){
         if(o!=null && !(o instanceof Serializable)
-                && !knownSerializable.contains(o)){
+                && !SerializerConstants.knownSerializable.contains(o)){
             throw new IllegalArgumentException("Not serializable: "+o.getClass());
         }
     }
@@ -54,7 +45,7 @@ public class SerializerBase implements Serializer{
     /**
      * Utility class similar to ArrayList, but with fast identity search.
      */
-    protected final static class FastArrayList<K> {
+    final static class FastArrayList<K> {
 
         private int size = 0;
         private K[] elementData = (K[]) new Object[1];
@@ -373,14 +364,6 @@ public class SerializerBase implements Serializer{
 
                     if(!packableLongs && !allNull)
                         break;
-                }
-            }else{
-                //check for all null
-                for (Object o : b) {
-                    if(o!=null){
-                        allNull=false;
-                        break;
-                    }
                 }
             }
             if(allNull){

--- a/src/main/java/org/mapdb/SerializerConstants.java
+++ b/src/main/java/org/mapdb/SerializerConstants.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2012 Jan Kotek
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapdb;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * collection of known serializers
+ */
+public class SerializerConstants {
+
+    static final Set knownSerializable = new HashSet(Arrays.asList(
+            BTreeKeySerializer.STRING,
+            BTreeKeySerializer.ZERO_OR_POSITIVE_LONG,
+            BTreeKeySerializer.ZERO_OR_POSITIVE_INT,
+
+            Utils.COMPARABLE_COMPARATOR, Utils.COMPARABLE_COMPARATOR_WITH_NULLS,
+
+            Serializer.STRING_SERIALIZER, Serializer.LONG_SERIALIZER, Serializer.INTEGER_SERIALIZER,
+            Serializer.EMPTY_SERIALIZER, Serializer.BASIC_SERIALIZER, Serializer.CRC32_CHECKSUM
+    ));
+
+}

--- a/src/test/java/org/mapdb/SerializerBaseTest.java
+++ b/src/test/java/org/mapdb/SerializerBaseTest.java
@@ -453,7 +453,7 @@ public class SerializerBaseTest extends TestCase {
 
 
     public void test_static_objects(){
-        for(Object o:SerializerBase.knownSerializable){
+        for(Object o:SerializerConstants.knownSerializable){
             assertTrue(o==Utils.clone(o, Serializer.BASIC_SERIALIZER));
         }
     }


### PR DESCRIPTION
Fix the load of SerializerBase class (static referencing SerializerBase). It cause aa dead lock in compiling using JDK 1.7
