### PR TITLE
Make DataOutput2 constructor public

### DIFF
--- a/src/main/java/org/mapdb/DataOutput2.java
+++ b/src/main/java/org/mapdb/DataOutput2.java
@@ -37,7 +37,7 @@ public final class DataOutput2 implements DataOutput {
         buf = new byte[16]; //TODO take hint from serializer for initial size
     }
 
-    byte[] copyBytes(){
+    public byte[] copyBytes(){
         return Arrays.copyOf(buf, pos);
     }
 


### PR DESCRIPTION
The class is public so the constructor should also be public so the class can be reused outside package.
The DataInput2 class already have a public constructor.
