### PR TITLE
Update maven-site-plugin to 3.3 so it is compatible with maven-3.1.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.3</version>
                 <dependencies>
                     <dependency>
                         <!-- Markdown support for writing website content -->
@@ -193,6 +193,12 @@
 
     <reporting>
         <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.7</version>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Update maven-site-plugin to 3.3 so it is compatible with maven-3.1.0.
Include definition for maven-project-info-reports-plugin to get rid of warning.
