### PR TITLE
Include jacoco for code coverage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,20 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.6.3.201306030806</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
 
         </plugins>
     </build>
@@ -217,6 +231,12 @@
                     <useStandardDocletOptions>true</useStandardDocletOptions>
                     <notimestamp>true</notimestamp>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.6.3.201306030806</version>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
I like to have code coverage, so I included the definition of jacoco. The results may be found at `target/site/jacoco/`.
