### PR TITLE
Include jacoco for code coverage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,9 +187,31 @@
                 </configuration>
             </plugin>
 
-
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>with-jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.6.3.201306030806</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <reporting>
         <plugins>


### PR DESCRIPTION
Hello,

I understand your concerns in regards of execution time and site size as expressed in #180.

I moved the execution of jacoco into a profile. Now by default it will not be executed. Running:

```
mvn -Pwith-jacoco clean verify (2m11s)
mvn clean verify (1m45s)
```

now will run tests with jacoco. On my machine (MacOSX 10.8.3, JDK 1.7.0_25 with a SSD) the difference between running with and without jacoco results in 2m11s versus 1m45s.
