### PR TITLE
Don't sync files to disk if deleteFilesAfterClose is true.

### DIFF
--- a/src/main/java/org/mapdb/StoreDirect.java
+++ b/src/main/java/org/mapdb/StoreDirect.java
@@ -653,8 +653,12 @@ public class StoreDirect extends Store{
                 }
             }
 
-            index.sync();
-            phys.sync();
+            // Syncs are expensive -- don't sync if the files are going to
+            // get deleted anyway.
+            if (!deleteFilesAfterClose) {
+              index.sync();
+              phys.sync();
+            }
             index.close();
             phys.close();
             if(deleteFilesAfterClose){


### PR DESCRIPTION
Fsyncing files if deleteFilesAfterClose causes an unneeded latency when the files are going to be deleted anyway. This fix checks if the files will be deleted immediately before syncing.
