### PR TITLE
Examples: fix capitalization typo

### DIFF
--- a/src/test/java/examples/TreeMap_Composite_Key.java
+++ b/src/test/java/examples/TreeMap_Composite_Key.java
@@ -35,7 +35,7 @@ public class TreeMap_Composite_Key {
 
         //initial values
         String[] towns = {"Galway", "Ennis", "Gort", "Cong", "Tuam"};
-        String[] streets = {"Main street", "Shop street", "Second street", "Silver Strands"};
+        String[] streets = {"Main Street", "Shop Street", "Second Street", "Silver Strands"};
         int[] houseNums = {1,2,3,4,5,6,7,8,9,10};
 
         DB db = DBMaker.newMemoryDB().make();


### PR DESCRIPTION
otherwise the "Salary sum for all Main Streets" comes back as 0.
