### PR TITLE
Fix for NPE while getting parent in Volume.checkFolder - see issue #292 ...

### DIFF
--- a/src/main/java/org/mapdb/Volume.java
+++ b/src/main/java/org/mapdb/Volume.java
@@ -678,6 +678,12 @@ public abstract class Volume {
 
         protected static void checkFolder(File file, boolean readOnly) throws IOException {
             File parent = file.getParentFile();
+            if(parent == null) {
+                parent = file.getCanonicalFile().getParentFile();
+            }
+            if (parent == null) {
+                throw new IOException("Parent folder could not be determined for: "+file);
+            }
             if(!parent.exists() || !parent.isDirectory())
                 throw new IOException("Parent folder does not exist: "+file);
             if(!parent.canRead())


### PR DESCRIPTION
Looks like getting canonical file works and does not break existing tests. I did not tried add special unit-test for this case since it looks like platform-related issue.
