### PR TITLE
Volume: Workaround for Windows and FileChannel truncate. Fix #326.

### DIFF
--- a/src/main/java/org/mapdb/StoreWAL.java
+++ b/src/main/java/org/mapdb/StoreWAL.java
@@ -68,7 +68,6 @@ public class StoreWAL extends StoreDirect {
             }
             replayPending = false;
             checkHeaders();
-            log = volFac.createTransLogVolume();
             if(!readOnly)
                 logReset();
             allGood = true;


### PR DESCRIPTION
StoreWAL contructor had duplicate call to createTransLogVolume(). It was quite hard to figure out this bug :)

On Windows, all mapped ByteBuffer must be unmaped before calling truncate.

Unit tests are passing.
