### PR TITLE
Issue 335.

### DIFF
--- a/src/main/java/org/mapdb/EngineWrapper.java
+++ b/src/main/java/org/mapdb/EngineWrapper.java
@@ -76,9 +76,13 @@ public class EngineWrapper implements Engine{
     @Override
     public void close() {
         Engine e = engine;
-        if(e!=null)
-            e.close();
-        engine = CLOSED;
+        if(e!=null) {
+            try {
+                e.close();
+            } finally {
+                engine = CLOSED;
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
A call to close will now release all resources even in the event that some file channels are already closed because of interrupted threads.

please see https://github.com/jankotek/MapDB/issues/335

Although this does NOT make mapDB work with interrupted threads, it does no worse by at least closing the File handles so, long running applications using mapDB don't run out of file handles.
