### PR TITLE
fix #335 Ensures that file resources are allways released.

### DIFF
--- a/src/main/java/org/mapdb/EngineWrapper.java
+++ b/src/main/java/org/mapdb/EngineWrapper.java
@@ -76,9 +76,12 @@ public class EngineWrapper implements Engine{
     @Override
     public void close() {
         Engine e = engine;
-        if(e!=null)
-            e.close();
-        engine = CLOSED;
+        try{
+            if(e!=null)
+                e.close();
+        } finally {
+            engine = CLOSED;
+        }
     }
 
     @Override


### PR DESCRIPTION
A call to close() in StoreDirect.java  will now release all resources even in the event that some file channels are already closed because of interrupted threads.

Also a call to close() will ensure that the engine is marked as closed.

Although this does NOT make mapDB work with interrupted threads, it does no worse by at least closing the File handles so, long running applications using mapDB don't run out of file handles.
