### PR TITLE
Fix issue removing transaction log after db close.

### DIFF
--- a/src/main/java/org/mapdb/StoreWAL.java
+++ b/src/main/java/org/mapdb/StoreWAL.java
@@ -73,19 +73,20 @@ public class StoreWAL extends StoreDirect {
         super(volFac, readOnly, deleteFilesAfterClose, spaceReclaimMode, syncOnCommitDisabled, sizeLimit,
                 checksum, compress, password,disableLocks, sizeIncrement);
         this.volFac = volFac;
-        this.log = volFac.createTransLogVolume();
 
         boolean allGood = false;
         if(!disableLocks) {
             structuralLock.lock();
         }
         try{
+		    this.log = volFac.createTransLogVolume();
             reloadIndexFile();
             if(verifyLogFile()){
                 replayLogFile();
             }
             replayPending = false;
             checkHeaders();
+			log.close();
             log = volFac.createTransLogVolume();
             if(!readOnly)
                 logReset();


### PR DESCRIPTION
There seems to a file resource leak in the constructor of StoreWAL. It
looks like it creates a transaction log to verify and replay any previous log that could exist. Then
it proceeds to create another transaction log of the same name without
closing the previous.
