### PR TITLE
set correct hasher when open exist hash tree map

### DIFF
--- a/src/main/java/org/mapdb/DB.java
+++ b/src/main/java/org/mapdb/DB.java
@@ -373,7 +373,7 @@ public class DB implements Closeable {
                 (long[])catGet(name+".expireHeads",null),
                 (long[])catGet(name+".expireTails",null),
                 valueCreator,
-                null,
+                catGet(name+".hasher", Hasher.BASIC),
                 false);
 
 


### PR DESCRIPTION
When create hash tree map, user can set a custom hasher. So when open the exist hash tree map, we should use the hasher which user set it before.
