### PR TITLE
Added OSGi dynamic import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
                         <Bundle-Name>${project.name}</Bundle-Name>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Import-Package>*</Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Added definition to OSGi descriptor to let the MapDB bundle load the classes from other bundles. This is necessary when a bundle uses loadClass and want  to laod class definition exposed by other bundle, not included at compile time.
