### PR TITLE
Add methods to specify size limits in bytes

### DIFF
--- a/src/main/java/org/mapdb/DB.java
+++ b/src/main/java/org/mapdb/DB.java
@@ -215,7 +215,7 @@ public class DB implements Closeable {
         }
 
         /** maximal size of store in bytes, if store is larger entries will start expiring */
-        public HTreeMapMaker expireStoreSizeBytes(long maxStoreSize) {
+        public HTreeMapMaker expireStoreSizeInBytes(long maxStoreSize) {
             this.expireStoreSize = maxStoreSize;
             return this;
         }
@@ -294,7 +294,7 @@ public class DB implements Closeable {
         }
 
         /** maximal size of store in bytes, if store is larger entries will start expiring */
-        public HTreeSetMaker expireStoreSizeBytes(long maxStoreSize){
+        public HTreeSetMaker expireStoreSizeInBytes(long maxStoreSize){
             this.expireStoreSize = maxStoreSize;
             return this;
         }

--- a/src/main/java/org/mapdb/DBMaker.java
+++ b/src/main/java/org/mapdb/DBMaker.java
@@ -681,11 +681,10 @@ public class DBMaker{
      * Limit is not strict and does not apply to some parts such as index table. Actual store size might
      * be 10% or more bigger.
      *
-     *
      * @param maxSize maximal store size in bytes
      * @return this builder
      */
-    public DBMaker sizeLimitBytes(long maxSize){
+    public DBMaker sizeLimitInBytes(long maxSize){
         props.setProperty(Keys.sizeLimit,""+maxSize);
         return this;
     }

--- a/src/test/java/org/mapdb/DBMakerTest.java
+++ b/src/test/java/org/mapdb/DBMakerTest.java
@@ -347,8 +347,8 @@ public class DBMakerTest{
         assertEquals(g/2,DBMaker.newMemoryDB().sizeLimit(0.5d).propsGetLong(DBMaker.Keys.sizeLimit,0));
         assertEquals(g,DBMaker.newMemoryDB().sizeLimit(1.0d).propsGetLong(DBMaker.Keys.sizeLimit,0));
 
-        assertEquals(g/2,DBMaker.newMemoryDB().sizeLimitBytes(512*1024*1024).propsGetLong(DBMaker.Keys.sizeLimit,0));
-        assertEquals(g,DBMaker.newMemoryDB().sizeLimitBytes(1024*1024*1024).propsGetLong(DBMaker.Keys.sizeLimit,0));
+        assertEquals(g/2,DBMaker.newMemoryDB().sizeLimitInBytes(512 * 1024 * 1024).propsGetLong(DBMaker.Keys.sizeLimit,0));
+        assertEquals(g,DBMaker.newMemoryDB().sizeLimitInBytes(1024 * 1024 * 1024).propsGetLong(DBMaker.Keys.sizeLimit,0));
     }
 
 


### PR DESCRIPTION
The existing methods (`HTreeMapMaker#expireStoreSize(double)`, `DBMaker#sizeLimit(double)`) with the size limit in gigabytes as double sometimes felt a bit clunky when specifying limits less than 1 GB.

This changeset adds methods to specify these limits in bytes as a long value.

In order to not break backward-compatibility the methods for specifying the size limits in bytes have a suffix "Bytes", e. g. `DBMaker#sizeLimitBytes(long)` instead of overloading the original methods, e. g. `DBMaker#sizeLimit(double)`.
