### PR TITLE
Reduces the usage of raw-types

### DIFF
--- a/src/main/java/org/mapdb/BTreeKeySerializer.java
+++ b/src/main/java/org/mapdb/BTreeKeySerializer.java
@@ -52,9 +52,9 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
     public abstract KEY getKey(KEYS keys, int pos);
 
 
-    public static final BTreeKeySerializer BASIC = new BTreeKeySerializer.BasicKeySerializer(Serializer.BASIC, Fun.COMPARATOR);
+    public static final BTreeKeySerializer<Object, Object[]> BASIC = new BTreeKeySerializer.BasicKeySerializer(Serializer.BASIC, Fun.COMPARATOR);
 
-    public abstract Comparator comparator();
+    public abstract Comparator<?> comparator();
 
     public abstract KEYS emptyKeys();
 
@@ -213,7 +213,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
         }
 
         @Override
-        public Comparator comparator() {
+        public Comparator<?> comparator() {
             return comparator;
         }
 
@@ -259,7 +259,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
      * Difference between consequential numbers is also packed itself, so for small diffs it takes only single byte per
      * number.
      */
-    public static final  BTreeKeySerializer LONG = new BTreeKeySerializer<Long,long[]>() {
+    public static final  BTreeKeySerializer<Long,long[]> LONG = new BTreeKeySerializer<Long,long[]>() {
 
         @Override
         public void serialize(DataOutput out, long[] keys) throws IOException {
@@ -309,7 +309,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
         }
 
         @Override
-        public Comparator comparator() {
+        public Comparator<?> comparator() {
             return Fun.COMPARATOR;
         }
 
@@ -433,7 +433,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
      * Difference between consequential numbers is also packed itself, so for small diffs it takes only single byte per
      * number.
      */
-    public static final  BTreeKeySerializer INTEGER = new BTreeKeySerializer<Integer,int[]>() {
+    public static final  BTreeKeySerializer<Integer,int[]> INTEGER = new BTreeKeySerializer<Integer,int[]>() {
         @Override
         public void serialize(DataOutput out, int[] keys) throws IOException {
             int prev = keys[0];
@@ -481,7 +481,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
         }
 
         @Override
-        public Comparator comparator() {
+        public Comparator<?> comparator() {
             return Fun.COMPARATOR;
         }
 
@@ -749,7 +749,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
         }
 
         @Override
-        public Comparator comparator() {
+        public Comparator<?> comparator() {
             return comparator;
         }
 
@@ -879,7 +879,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
         }
 
         @Override
-        public Comparator comparator() {
+        public Comparator<?> comparator() {
             return Fun.COMPARATOR;
         }
 
@@ -1549,7 +1549,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
         }
 
         @Override
-        public Comparator comparator() {
+        public Comparator<?> comparator() {
             return Fun.COMPARATOR;
         }
 
@@ -1677,7 +1677,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
         }
 
         @Override
-        public Comparator comparator() {
+        public Comparator<?> comparator() {
             return Fun.COMPARATOR;
         }
 
@@ -1809,7 +1809,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
         }
 
         @Override
-        public Comparator comparator() {
+        public Comparator<?> comparator() {
             return Fun.BYTE_ARRAY_COMPARATOR;
         }
 
@@ -1919,7 +1919,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
         }
 
         @Override
-        public Comparator comparator() {
+        public Comparator<?> comparator() {
             return Fun.BYTE_ARRAY_COMPARATOR;
         }
 
@@ -2033,7 +2033,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
         }
 
         @Override
-        public Comparator comparator() {
+        public Comparator<?> comparator() {
             return wrapped.comparator();
         }
 

--- a/src/main/java/org/mapdb/DB.java
+++ b/src/main/java/org/mapdb/DB.java
@@ -933,7 +933,7 @@ public class DB implements Closeable {
                 catGet(name+".maxNodeSize",32),
                 catGet(name+".valuesOutsideNodes",false),
                 catGet(name+".counterRecid",0L),
-                catGet(name+".keySerializer",new BTreeKeySerializer.BasicKeySerializer(getDefaultSerializer(),Fun.getComparator())),
+                catGet(name+".keySerializer",new BTreeKeySerializer.BasicKeySerializer(getDefaultSerializer(),Fun.COMPARATOR)),
                 catGet(name+".valueSerializer",getDefaultSerializer()),
                 catGet(name+".numberOfNodeMetas",0)
                 );
@@ -959,7 +959,7 @@ public class DB implements Closeable {
         checkNameNotExists(name);
         //$DELAY$
         if(m.comparator==null){
-            m.comparator = Fun.getComparator();
+            m.comparator = Fun.COMPARATOR;
         }
 
         m.keySerializer = fillNulls(m.keySerializer);
@@ -1029,7 +1029,7 @@ public class DB implements Closeable {
             //$DELAY$
             for (int i = 0; i < k.tsize; i++) {
                 serializers[i] = k.serializers[i] != null && k.serializers[i]!=Serializer.BASIC ? k.serializers[i] : getDefaultSerializer();
-                comparators[i] = k.comparators[i] != null ? k.comparators[i] : Fun.getComparator();
+                comparators[i] = k.comparators[i] != null ? k.comparators[i] : Fun.COMPARATOR;
             }
             //$DELAY$
             return new BTreeKeySerializer.ArrayKeySerializer(comparators, serializers);
@@ -1083,7 +1083,7 @@ public class DB implements Closeable {
                 catGet(name+".maxNodeSize",32),
                 false,
                 catGet(name+".counterRecid",0L),
-                catGet(name+".keySerializer",new BTreeKeySerializer.BasicKeySerializer(getDefaultSerializer(),Fun.getComparator())),
+                catGet(name+".keySerializer",new BTreeKeySerializer.BasicKeySerializer(getDefaultSerializer(),Fun.COMPARATOR)),
                 null,
                 catGet(name+".numberOfNodeMetas",0)
         ).keySet();
@@ -1106,7 +1106,7 @@ public class DB implements Closeable {
     synchronized public <K> NavigableSet<K> createTreeSet(BTreeSetMaker m){
         checkNameNotExists(m.name);
         if(m.comparator==null){
-            m.comparator = Fun.getComparator();
+            m.comparator = Fun.COMPARATOR;
         }
         //$DELAY$
         m.serializer = fillNulls(m.serializer);

--- a/src/main/java/org/mapdb/DBMaker.java
+++ b/src/main/java/org/mapdb/DBMaker.java
@@ -37,7 +37,7 @@ public class DBMaker{
 
     protected final String TRUE = "true";
 
-    protected Fun.RecordCondition cacheCondition;
+    protected Fun.RecordCondition<?> cacheCondition;
     protected ScheduledExecutorService executor;
 
     protected interface Keys{
@@ -351,7 +351,7 @@ public class DBMaker{
      *
      * @return this builder
      */
-    public DBMaker cacheCondition(Fun.RecordCondition cacheCondition){
+    public DBMaker cacheCondition(Fun.RecordCondition<?> cacheCondition){
         this.cacheCondition = cacheCondition;
         return this;
     }
@@ -869,7 +869,7 @@ public class DBMaker{
             //new db, so insert testing record
             byte[] b = new byte[127];
             new Random().nextBytes(b);
-            check = new Fun.Pair(Arrays.hashCode(b), b);
+            check = new Fun.Pair<Integer, byte[]>(Arrays.hashCode(b), b);
             engine.update(Engine.RECID_RECORD_CHECK, check, Serializer.BASIC);
             engine.commit();
         }

--- a/src/main/java/org/mapdb/Fun.java
+++ b/src/main/java/org/mapdb/Fun.java
@@ -86,7 +86,21 @@ public final class Fun {
     public static <T> Iterator<T> getEmptyIerator(){
     	return new ArrayList<T>().iterator();
     }
-    
+    /**
+     * checks whether a given iterator is null or empty(contains no elements).
+     * It calls {@link java.util.Iterator#hasNext()} internally
+     * @param iterator
+     * @return
+     */
+    public static boolean isNullOrEmptyIterator(Iterator<?> iterator){
+    	if(iterator==null){
+    		return true;
+    	}
+    	while(iterator.hasNext()){
+			return false;
+		}
+		return true;
+    }
     private Fun(){}
 
     /** returns true if all elements are equal, works with nulls*/

--- a/src/main/java/org/mapdb/Fun.java
+++ b/src/main/java/org/mapdb/Fun.java
@@ -28,25 +28,65 @@ import java.util.*;
  */
 public final class Fun {
 
-    public static final Comparator COMPARATOR = new Comparator<Comparable>() {
+	/**
+	 * A utility method for getting a type-safe Comparator, it provides type-inference help.
+	 * Use this method instead of {@link org.mapdb.Fun.COMPARATOR} in order to insure type-safety 
+	 * ex: Comparator<Integer> comparator = getComparator();
+	 * @return comparator
+	 */
+	public static <T extends Comparable<T>> Comparator<T> getComparator(){
+		
+		Comparator<T> comparator = new Comparator<T>() {
+			@Override
+			public int compare(T o1, T o2) {
+				return o1.compareTo(o2);
+			}
+			
+		};
+		return comparator;
+	}
+	
+	/**
+	 * A utility method for getting a type-safe reversed Comparator (the negation of {@link org.mapdb.Fun.getComparator()}). 
+	 * Use this method instead of {@link org.mapdb.Fun.REVERSE_COMPARATOR} in order to insure type-safety 
+	 * ex: Comparator<Integer> comparator = getReversedComparator();
+	 * @return comparator
+	 */
+	public static <T extends Comparable<T>> Comparator<T> getReversedComparator(){
+		
+		Comparator<T> comparator = new Comparator<T>() {
+			@Override
+			public int compare(T o1, T o2) {
+				Comparator<T> comparator = getComparator();
+				return - comparator.compare(o1, o2);
+			}
+			
+		};
+		return comparator;
+	}
+	
+    @SuppressWarnings("rawtypes")
+	public static final Comparator COMPARATOR = new Comparator<Comparable>() {
         @Override
         public int compare(Comparable o1, Comparable o2) {
             return o1.compareTo(o2);
         }
     };
 
-    public static final Comparator<Comparable> REVERSE_COMPARATOR = new Comparator<Comparable>() {
+    @SuppressWarnings("rawtypes")
+	public static final Comparator<Comparable> REVERSE_COMPARATOR = new Comparator<Comparable>() {
         @Override
         public int compare(Comparable o1, Comparable o2) {
             return -COMPARATOR.compare(o1,o2);
         }
     };
 
-
-    /** empty iterator (note: Collections.EMPTY_ITERATOR is Java 7 specific and should not be used)*/
     public static final Iterator EMPTY_ITERATOR = new ArrayList(0).iterator();
 
-
+    public static <T> Iterator<T> getEmptyIerator(){
+    	return new ArrayList<T>().iterator();
+    }
+    
     private Fun(){}
 
     /** returns true if all elements are equal, works with nulls*/
@@ -107,16 +147,16 @@ public final class Fun {
 
 
         @Override public int compareTo(Pair<A,B> o) {
-            int i = ((Comparable)a).compareTo(o.a);
+            int i = ((Comparable<A>)a).compareTo(o.a);
             if(i!=0)
                 return i;
-            return ((Comparable)b).compareTo(o.b);
+            return ((Comparable<B>)b).compareTo(o.b);
         }
 
         @Override public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            final Pair t = (Pair) o;
+            final Pair<?, ?> t = (Pair<?,?>) o;
             return eq(a,t.a) && eq(b,t.b);
         }
 
@@ -349,9 +389,10 @@ public final class Fun {
             public Iterator<Object[]> iterator() {
                 final Iterator<Object[]> iter = set.tailSet(keys).iterator();
 
-                if(!iter.hasNext())
-                    return Fun.EMPTY_ITERATOR;
-
+                if(!iter.hasNext()){
+                    return Fun.getEmptyIerator();
+                }
+                
                 return new Iterator<Object[]>() {
 
                     Object[] next = moveToNext();
@@ -404,9 +445,9 @@ public final class Fun {
     }
 
     /**  record condition which always returns true*/
-    public static final RecordCondition RECORD_ALWAYS_TRUE = new RecordCondition() {
+    public static final RecordCondition<Object> RECORD_ALWAYS_TRUE = new RecordCondition<Object>() {
         @Override
-        public boolean run(long recid, Object value, Serializer serializer) {
+        public boolean run(long recid, Object value, Serializer<Object> serializer) {
             return true;
         }
     };

--- a/src/main/java/org/mapdb/Pump.java
+++ b/src/main/java/org/mapdb/Pump.java
@@ -37,14 +37,14 @@ public final class Pump {
      * @param serializer used to store data in temporary files
      * @return iterator over sorted data set
      */
-    public static <E> Iterator<E> sort(Iterator<E> source, boolean mergeDuplicates, final int batchSize,
-            Comparator comparator, final Serializer serializer){
+    public static <E extends Comparable<E>> Iterator<E> sort(Iterator<E> source, boolean mergeDuplicates, final int batchSize,
+            Comparator<E> comparator, final Serializer<E> serializer){
         if(batchSize<=0) throw new IllegalArgumentException();
         if(comparator==null)
-            comparator=Fun.COMPARATOR;
+            comparator=Fun.getComparator();
         if(source==null)
-            source = Fun.EMPTY_ITERATOR;
-
+            source = Fun.getEmptyIerator();
+        final Comparator comparator2 = comparator; //TODO: a better solution to avoid the raw Comparator 
         int counter = 0;
         final Object[] presort = new Object[batchSize];
         final List<File> presortFiles = new ArrayList<File>();
@@ -57,7 +57,7 @@ public final class Pump {
 
                 if(counter>=batchSize){
                     //sort all items
-                    Arrays.sort(presort,comparator);
+                    Arrays.sort(presort,comparator2);
 
                     //flush presort into temporary file
                     File f = File.createTempFile("mapdb","sort");
@@ -65,7 +65,7 @@ public final class Pump {
                     presortFiles.add(f);
                     DataOutputStream out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(f)));
                     for(Object e:presort){
-                        serializer.serialize(out,e);
+                        serializer.serialize(out,(E)e);
                     }
                     out.close();
                     presortCount2.add(counter);
@@ -76,7 +76,7 @@ public final class Pump {
             //now all records from source are fetch
             if(presortFiles.isEmpty()){
                 //no presort files were created, so on-heap sorting is enough
-                Arrays.sort(presort,0,counter,comparator);
+                Arrays.sort(presort,0,counter,comparator2);
                 return arrayIterator(presort,0, counter);
             }
 
@@ -115,7 +115,7 @@ public final class Pump {
             }
 
             //and add iterator over data on-heap
-            Arrays.sort(presort,0,counter,comparator);
+            Arrays.sort(presort,0,counter,comparator2);
             iterators[iterators.length-1] = arrayIterator(presort,0,counter);
 
             //and finally sort presorted iterators and return iterators over them
@@ -139,12 +139,12 @@ public final class Pump {
      * @param iterators array of already sorted iterators
      * @return sorted iterator
      */
-    public static <E> Iterator<E> sort(Comparator comparator, final boolean mergeDuplicates, final Iterator... iterators) {
-        final Comparator comparator2 = comparator==null?Fun.COMPARATOR:comparator;
+    public static <E> Iterator<E> sort(Comparator<E> comparator, final boolean mergeDuplicates, final Iterator<E>... iterators) {
+        final Comparator comparator2 = comparator==null?Fun.getComparator():comparator;
         return new Iterator<E>(){
 
             final NavigableSet<Object[]> items = new TreeSet<Object[]>(
-                    new Fun.ArrayComparator(new Comparator[]{comparator2,Fun.COMPARATOR}));
+                    new Fun.ArrayComparator(new Comparator[]{comparator2,Fun.getComparator()}));
 
             Object next = this; //is initialized with this so first `next()` will not throw NoSuchElementException
 
@@ -190,7 +190,7 @@ public final class Pump {
                         Iterator<Object[]> subset = Fun.filter(items,next).iterator();
                         if(!subset.hasNext())
                             break;
-                        List toadd = new ArrayList();
+                        List<Object[]> toadd = new ArrayList<Object[]>();
                         while(subset.hasNext()){
                             Object[] t = subset.next();
                             items.remove(t);
@@ -222,9 +222,9 @@ public final class Pump {
      * @param iters - iterators to be merged
      * @return union of all iterators.
      */
-    public static <E> Iterator<E> merge(final Iterator... iters){
+    public static <E> Iterator<E> merge(final Iterator<E>... iters){
         if(iters.length==0)
-            return Fun.EMPTY_ITERATOR;
+            return Fun.getEmptyIerator();
 
         return new Iterator<E>() {
 
@@ -540,12 +540,13 @@ public final class Pump {
         };
     }
 
-    public static <K, V,A> void fillHTreeMap(final HTreeMap<K, V> m,
+    public static <K, V,A extends Comparable<A>> void fillHTreeMap(final HTreeMap<K, V> m,
                                              Iterator<A> pumpSource,
                                              final Fun.Function1<K,A> pumpKeyExtractor,
                                              Fun.Function1<V,A> pumpValueExtractor,
                                              int pumpPresortBatchSize, boolean pumpIgnoreDuplicates,
                                              Serializer<A> sortSerializer) {
+    	
 
         //first sort by hash code
         Comparator hashComparator = new Comparator() {

--- a/src/main/java/org/mapdb/Pump.java
+++ b/src/main/java/org/mapdb/Pump.java
@@ -288,6 +288,7 @@ public final class Pump {
      * @param counterRecid TODO make size counter friendly to use
      * @param keySerializer serializer for keys, use null for default value
      * @param valueSerializer serializer for value, use null for default value
+     * @throws IllegalArgumentException if source iterator is null or empty
      * @throws IllegalArgumentException if source iterator is not reverse sorted
      */
     public static  <E,K,V> long buildTreeMap(Iterator<E> source,
@@ -301,7 +302,9 @@ public final class Pump {
                                              BTreeKeySerializer keySerializer,
                                              Serializer<V> valueSerializer)
         {
-
+    	if(Fun.isNullOrEmptyIterator(source)){
+    		throw new IllegalArgumentException("source iterator cannot be empty");
+    	}
 
         final double NODE_LOAD = 0.75;
 

--- a/src/main/java/org/mapdb/Pump.java
+++ b/src/main/java/org/mapdb/Pump.java
@@ -140,11 +140,11 @@ public final class Pump {
      * @return sorted iterator
      */
     public static <E> Iterator<E> sort(Comparator<E> comparator, final boolean mergeDuplicates, final Iterator<E>... iterators) {
-        final Comparator comparator2 = comparator==null?Fun.getComparator():comparator;
+        final Comparator comparator2 = comparator==null?Fun.COMPARATOR:comparator;
         return new Iterator<E>(){
 
             final NavigableSet<Object[]> items = new TreeSet<Object[]>(
-                    new Fun.ArrayComparator(new Comparator[]{comparator2,Fun.getComparator()}));
+                    new Fun.ArrayComparator(new Comparator[]{comparator2,Fun.COMPARATOR}));
 
             Object next = this; //is initialized with this so first `next()` will not throw NoSuchElementException
 

--- a/src/main/java/org/mapdb/Queues.java
+++ b/src/main/java/org/mapdb/Queues.java
@@ -89,10 +89,10 @@ public final class Queues {
         @Override
         public E peek() {
             final long head2 = head.get();
-            Node n = engine.get(head2,nodeSerializer);
+            Node<E> n = engine.get(head2,nodeSerializer);
             if(n==null)
                 return null; //empty queue
-            return (E) n.value;
+            return n.value;
         }
 
 
@@ -100,7 +100,7 @@ public final class Queues {
         public E poll() {
             for(;;){
                 final long head2 = head.get();
-                Node n = engine.get(head2,nodeSerializer);
+                Node<E> n = engine.get(head2,nodeSerializer);
                 if(n==null)
                     return null; //empty queue
 
@@ -108,7 +108,7 @@ public final class Queues {
                 if(head.compareAndSet(head2,n.next)){
                     //updated fine, so we can take a value
                     engine.delete(head2,nodeSerializer);
-                    return (E) n.value;
+                    return n.value;
                 }
             }
         }
@@ -129,7 +129,7 @@ public final class Queues {
                 if (this == o) return true;
                 if (o == null || getClass() != o.getClass()) return false;
 
-                Node node = (Node) o;
+                Node<E> node = (Node<E>) o;
 
                 if (next != node.next) return false;
                 if (value != null ? !value.equals(node.value) : node.value != null) return false;
@@ -359,7 +359,7 @@ public final class Queues {
                 tail2 = tail.get();
             }
             //now we have tail2 just for us
-            Node<E> n = new Node(nextTail,e);
+            Node<E> n = new Node<E>(nextTail,e);
             engine.update(tail2,n,nodeSerializer);
             return true;
         }

--- a/src/main/java/org/mapdb/Serializer.java
+++ b/src/main/java/org/mapdb/Serializer.java
@@ -1079,15 +1079,15 @@ public abstract class Serializer<A> {
     } ;
 
 
-    public static final Serializer<Class> CLASS = new Serializer<Class>() {
+    public static final Serializer<Class<?>> CLASS = new Serializer<Class<?>>() {
 
         @Override
-        public void serialize(DataOutput out, Class value) throws IOException {
+        public void serialize(DataOutput out, Class<?> value) throws IOException {
             out.writeUTF(value.getName());
         }
 
         @Override
-        public Class deserialize(DataInput in, int available) throws IOException {
+        public Class<?> deserialize(DataInput in, int available) throws IOException {
             return SerializerPojo.classForName(in.readUTF());
         }
 
@@ -1097,12 +1097,12 @@ public abstract class Serializer<A> {
         }
 
         @Override
-        public boolean equals(Class a1, Class a2) {
+        public boolean equals(Class<?> a1, Class<?> a2) {
             return a1==a2 || (a1.toString().equals(a2.toString()));
         }
 
         @Override
-        public int hashCode(Class aClass) {
+        public int hashCode(Class<?> aClass) {
             //class does not override identity hash code
             return aClass.toString().hashCode();
         }
@@ -1149,7 +1149,8 @@ public abstract class Serializer<A> {
         }
 
         /** used for deserialization */
-        protected CompressionWrapper(SerializerBase serializerBase, DataInput is, SerializerBase.FastArrayList<Object> objectStack) throws IOException {
+        @SuppressWarnings("unchecked")
+		protected CompressionWrapper(SerializerBase serializerBase, DataInput is, SerializerBase.FastArrayList<Object> objectStack) throws IOException {
             objectStack.add(this);
             this.serializer = (Serializer<E>) serializerBase.deserialize(is,objectStack);
         }
@@ -1200,7 +1201,7 @@ public abstract class Serializer<A> {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
-            CompressionWrapper that = (CompressionWrapper) o;
+            CompressionWrapper<?> that = (CompressionWrapper<?>) o;
             return serializer.equals(that.serializer);
         }
 
@@ -1215,36 +1216,39 @@ public abstract class Serializer<A> {
         }
     }
 
-    public static final class Array extends Serializer<Object[]> implements  Serializable{
+    public static final class Array<T> extends Serializer<T[]> implements  Serializable{
 
-        protected final Serializer serializer;
+		private static final long serialVersionUID = -7443421486382532062L;
+		protected final Serializer<T> serializer;
 
-        public Array(Serializer serializer) {
+        public Array(Serializer<T> serializer) {
             this.serializer = serializer;
         }
 
         /** used for deserialization */
-        protected Array(SerializerBase serializerBase, DataInput is, SerializerBase.FastArrayList<Object> objectStack) throws IOException {
+        @SuppressWarnings("unchecked")
+		protected Array(SerializerBase serializerBase, DataInput is, SerializerBase.FastArrayList<Object> objectStack) throws IOException {
             objectStack.add(this);
-            this.serializer = (Serializer) serializerBase.deserialize(is,objectStack);
+            this.serializer = (Serializer<T>) serializerBase.deserialize(is,objectStack);
         }
 
 
         @Override
-        public void serialize(DataOutput out, Object[] value) throws IOException {
+        public void serialize(DataOutput out, T[] value) throws IOException {
             DataIO.packInt(out,value.length);
-            for(Object a:value){
+            for(T a:value){
                 serializer.serialize(out,a);
             }
         }
 
         @Override
-        public Object[] deserialize(DataInput in, int available) throws IOException {
-            Object[] ret = new Object[DataIO.unpackInt(in)];
+        public T[] deserialize(DataInput in, int available) throws IOException {
+        	T[] ret =(T[]) new Object[DataIO.unpackInt(in)];
             for(int i=0;i<ret.length;i++){
                 ret[i] = serializer.deserialize(in,-1);
             }
             return ret;
+            
         }
 
         @Override
@@ -1253,7 +1257,7 @@ public abstract class Serializer<A> {
         }
 
         @Override
-        public boolean equals(Object[] a1, Object[] a2) {
+        public boolean equals(T[] a1, T[] a2) {
             if(a1==a2)
                 return true;
             if(a1==null || a1.length!=a2.length)
@@ -1267,9 +1271,9 @@ public abstract class Serializer<A> {
         }
 
         @Override
-        public int hashCode(Object[] objects) {
+        public int hashCode(T[] objects) {
             int ret = objects.length;
-            for(Object a:objects){
+            for(T a:objects){
                 ret=31*ret+serializer.hashCode(a);
             }
             return ret;
@@ -1279,7 +1283,7 @@ public abstract class Serializer<A> {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            return serializer.equals(((Array) o).serializer);
+            return serializer.equals(((Array<?>) o).serializer);
 
         }
 
@@ -1291,7 +1295,7 @@ public abstract class Serializer<A> {
 
     //this has to be lazily initialized due to circular dependencies
     static final  class __BasicInstance {
-        final static Serializer s = new SerializerBase();
+        final static Serializer<Object> s = new SerializerBase();
     }
 
 
@@ -1300,8 +1304,7 @@ public abstract class Serializer<A> {
      * It does not handle custom POJO classes. It also does not handle classes which
      * require access to `DB` itself.
      */
-    @SuppressWarnings("unchecked")
-    public static final Serializer<Object> BASIC = new Serializer(){
+    public static final Serializer<Object> BASIC = new Serializer<Object>(){
 
         @Override
         public void serialize(DataOutput out, Object value) throws IOException {
@@ -1326,7 +1329,7 @@ public abstract class Serializer<A> {
      * @param out ObjectOutput to save object into
      * @param value Object to serialize
      */
-    abstract public void serialize( DataOutput out, A value)
+    abstract public void serialize(DataOutput out, A value)
             throws IOException;
 
 
@@ -1363,7 +1366,8 @@ public abstract class Serializer<A> {
         return a.hashCode();
     }
 
-    public void valueArraySerialize(DataOutput out, Object vals) throws IOException {
+    @SuppressWarnings("unchecked")
+	public void valueArraySerialize(DataOutput out, Object vals) throws IOException {
         Object[] vals2 = (Object[]) vals;
         for(Object o:vals2){
             serialize(out, (A) o);
@@ -1378,7 +1382,8 @@ public abstract class Serializer<A> {
         return ret;
     }
 
-    public A valueArrayGet(Object vals, int pos){
+    @SuppressWarnings("unchecked")
+	public A valueArrayGet(Object vals, int pos){
         return (A) ((Object[])vals)[pos];
     }
 

--- a/src/main/java/org/mapdb/SerializerPojo.java
+++ b/src/main/java/org/mapdb/SerializerPojo.java
@@ -240,7 +240,7 @@ public class SerializerPojo extends SerializerBase implements Serializable{
 
     public static ClassInfo makeClassInfo(String className){
         try {
-            Class clazz = Class.forName(className); //TODO class loader
+            Class<?> clazz = Class.forName(className); //TODO class loader
             final boolean advancedSer = usesAdvancedSerialization(clazz);
             ObjectStreamField[] streamFields = advancedSer ? new ObjectStreamField[0] : makeFieldsForClass(clazz);
             FieldInfo[] fields = new FieldInfo[streamFields.length];
@@ -505,7 +505,7 @@ public class SerializerPojo extends SerializerBase implements Serializable{
 
     static{
         try{
-            Class clazz = classForName("sun.reflect.ReflectionFactory");
+            Class<?> clazz = classForName("sun.reflect.ReflectionFactory");
             if(clazz!=null){
                 Method getReflectionFactory = clazz.getMethod("getReflectionFactory");
                 sunReflFac = getReflectionFactory.invoke(null);
@@ -639,14 +639,14 @@ public class SerializerPojo extends SerializerBase implements Serializable{
                 //gets its name in catalog
                 className = classes[classId].name;
             }
-            Class clazz = Class.forName(className);
+            Class<?> clazz = Class.forName(className);
             return ObjectStreamClass.lookup(clazz);
         }
 
         @Override
         protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
             ClassLoader loader = Thread.currentThread().getContextClassLoader();
-            Class clazz = Class.forName(desc.getName(), false, loader);
+            Class<?> clazz = Class.forName(desc.getName(), false, loader);
             if (clazz != null)
                 return clazz;
             return super.resolveClass(desc);

--- a/src/main/java/org/mapdb/TxEngine.java
+++ b/src/main/java/org/mapdb/TxEngine.java
@@ -381,7 +381,7 @@ public class TxEngine implements Engine {
             commitLock.writeLock().lock();
             try{
                 Long recid = preallocRecidTake();
-                mod.put(recid, new Fun.Pair(value,serializer));
+                mod.put(recid, new Fun.Pair<A,Serializer<A>>(value,serializer));
                 return recid;
             }finally {
                 commitLock.writeLock().unlock();

--- a/src/test/java/org/mapdb/FunTest.java
+++ b/src/test/java/org/mapdb/FunTest.java
@@ -2,6 +2,7 @@ package org.mapdb;
 
 
 import java.util.Comparator;
+import java.util.Iterator;
 
 import org.junit.Test;
 
@@ -95,5 +96,49 @@ public class FunTest {
     	assertEquals(-1, stringComparator.compare(b, a));
     }
     
+    @Test
+    public void test_isNullOrEmptyIterator(){
+    	Iterator<String> emptyIterator = new Iterator<String>() {
+			
+			@Override
+			public void remove() {
+			}
+			
+			@Override
+			public String next() {
+				return null;
+			}
+			
+			@Override
+			public boolean hasNext() {
+				return false;
+			}
+		};
+		
+		assertTrue(Fun.isNullOrEmptyIterator(emptyIterator));
+		
+		Iterator<String> nullIterator = null;
+		assertTrue(Fun.isNullOrEmptyIterator(nullIterator));
+		
+		Iterator<String> nonEmptyIterator = new Iterator<String>() {
+
+			@Override
+			public boolean hasNext() {
+				return true;
+			}
+
+			@Override
+			public String next() {
+				return null;
+			}
+
+			@Override
+			public void remove() {
+			}
+		};
+		
+		assertFalse(Fun.isNullOrEmptyIterator(nonEmptyIterator));
+    	
+    }
     
 }

--- a/src/test/java/org/mapdb/FunTest.java
+++ b/src/test/java/org/mapdb/FunTest.java
@@ -1,6 +1,8 @@
 package org.mapdb;
 
 
+import java.util.Comparator;
+
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -68,4 +70,30 @@ public class FunTest {
         assertEquals(0, Fun.BYTE_ARRAY_COMPARATOR.compare(b1,b1));
         assertEquals(0, Fun.BYTE_ARRAY_COMPARATOR.compare(b1,b1_));
     }
+    
+    @Test
+    public void getComparator(){
+    	Comparator<String> stringComparator = Fun.getComparator();
+    	String a = "A";
+    	String a1 = "A";
+    	String b= "B";
+    	
+    	assertEquals(0, stringComparator.compare(a, a1));
+    	assertEquals(-1, stringComparator.compare(a, b));
+    	assertEquals(1, stringComparator.compare(b, a));
+    }
+    
+    @Test
+    public void getReveresedComparator(){
+    	Comparator<String> stringComparator = Fun.getReversedComparator();
+    	String a = "A";
+    	String a1 = "A";
+    	String b= "B";
+    	
+    	assertEquals(0, stringComparator.compare(a, a1));
+    	assertEquals(1, stringComparator.compare(a, b));
+    	assertEquals(-1, stringComparator.compare(b, a));
+    }
+    
+    
 }

--- a/src/test/java/org/mapdb/Issue452Test.java
+++ b/src/test/java/org/mapdb/Issue452Test.java
@@ -1,0 +1,35 @@
+package org.mapdb;
+import java.util.Iterator;
+
+import org.junit.Test;
+
+public class Issue452Test {
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void test_throws_exception_if_source_iterator_is_empty(){
+		Iterator<Fun.Pair<String,String>> data = new Iterator<Fun.Pair<String,String>> () {
+			@Override
+			public boolean hasNext() {
+				return false;
+			}
+	
+			@Override
+			public Fun.Pair<String,String> next() {
+				return null;
+			}
+	
+			@Override
+			public void remove() {
+				// TODO Auto-generated method stub
+			}	
+		};
+		
+		DB db = DBMaker.newTempFileDB()
+				.make();
+		
+		db.createTreeMap("test")
+			.pumpSource(data)
+			.make();
+	}
+
+}

--- a/src/test/java/org/mapdb/PumpTest.java
+++ b/src/test/java/org/mapdb/PumpTest.java
@@ -371,11 +371,11 @@ public class PumpTest {
 
 
     @Test public void merge(){
-        Iterator i = Pump.merge(
+        Iterator<String> i = Pump.merge(
                 Arrays.asList("a","b").iterator(),
-                Arrays.asList().iterator(),
+                new ArrayList<String>().iterator(),
                 Arrays.asList("c","d").iterator(),
-                Arrays.asList().iterator()
+                new ArrayList<String>().iterator()
         );
 
         assertTrue(i.hasNext());

--- a/src/test/java/org/mapdb/SerializerTest.java
+++ b/src/test/java/org/mapdb/SerializerTest.java
@@ -3,6 +3,7 @@ package org.mapdb;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
@@ -40,13 +41,10 @@ public class SerializerTest {
         assertTrue(out.pos<1000);
     }
 
-    @Test public void array(){
-        Serializer.Array s = new Serializer.Array(Serializer.INTEGER);
-
-        Object[] a = new Object[]{1,2,3,4};
-
+    @Test public void array() throws IOException{
+        Serializer.Array<Integer> s = new Serializer.Array<Integer>(Serializer.INTEGER);
+        Integer[] a = new Integer[]{1,2,3,4};
         assertArrayEquals(a, UtilsTest.clone(a,s));
         assertEquals(s,UtilsTest.clone(s,Serializer.BASIC));
-
     }
 }


### PR DESCRIPTION
I did the build 3 times on Travis CI and it was failing on openjdk1.6 but it finally passed.
https://travis-ci.org/SleimanJneidi/MapDB/builds/55293481
Thats because the tests are memory hungry. 
  