### PR TITLE
Optimize POJO deserialization

### DIFF
--- a/src/main/java/org/mapdb/DB.java
+++ b/src/main/java/org/mapdb/DB.java
@@ -2128,12 +2128,13 @@ public class DB implements Closeable {
                 SerializerPojo.ClassInfo[] classes = serializerPojo.getClassInfos.run();
                 SerializerPojo.ClassInfo[] classes2 = classes.length == 0 ? null : classes;
 
+                final ClassLoader classLoader = SerializerPojo.classForNameClassLoader();
                 for (String className : toBeAdded) {
-                    int pos = serializerPojo.classToId(classes, className);
+                    int pos = SerializerPojo.classToId(classes, className);
                     if (pos != -1) {
                         continue;
                     }
-                    SerializerPojo.ClassInfo classInfo = serializerPojo.makeClassInfo(className);
+                    SerializerPojo.ClassInfo classInfo = SerializerPojo.makeClassInfo(classLoader, className);
                     classes = Arrays.copyOf(classes, classes.length + 1);
                     classes[classes.length - 1] = classInfo;
                 }

--- a/src/test/java/examples/PojoPerformance.java
+++ b/src/test/java/examples/PojoPerformance.java
@@ -1,0 +1,4 @@
+package examples;
+
+public class PojoPerformance {
+}

--- a/src/test/java/examples/PojoPerformance.java
+++ b/src/test/java/examples/PojoPerformance.java
@@ -1,4 +1,0 @@
-package examples;
-
-public class PojoPerformance {
-}


### PR DESCRIPTION
I had problems with MapDB performance on DBs that contained many POJOs. This PR contains the changes I needed to make in order to make all the uses of reflection disappear from my profiling. The most important change is that we should not deserialize the ClassInfo[] once for every POJO we want to deserialize. My changes to avoid calling Class.forName getContextClassLoader are less important but still yield a nice speedup.