### PR TITLE
make sure buffer reads and skips are completed fully to the size expe…

### DIFF
--- a/src/main/java/org/mapdb/DataIO.java
+++ b/src/main/java/org/mapdb/DataIO.java
@@ -491,6 +491,10 @@ public final class DataIO {
             read+=c;
         }
     }
+    
+    public static void skipFully(InputStream in, long length) throws IOException {
+        while ((length -= in.skip(length)) > 0);
+    }
 
 
     /**

--- a/src/main/java/org/mapdb/Pump.java
+++ b/src/main/java/org/mapdb/Pump.java
@@ -860,7 +860,7 @@ public final class Pump {
             InputStream[] ins = new InputStream[files.length];
             for(int i=0;i<ins.length;i++){
                 ins[i] = new FileInputStream(files[i]);
-                ins[i].skip(40);
+                DataIO.skipFully(ins[i], 40);
             }
 
             DB db = maker.make();

--- a/src/main/java/org/mapdb/StoreDirect.java
+++ b/src/main/java/org/mapdb/StoreDirect.java
@@ -1232,7 +1232,7 @@ public class StoreDirect extends Store {
                             //so skip length and continue
                             long toSkip = len - 1;
                             if (toSkip > 0) {
-                                in.skip(toSkip);
+                                DataIO.skipFully(in, toSkip);
                             }
                             continue recidLoop;
                         }

--- a/src/main/java/org/mapdb/Volume.java
+++ b/src/main/java/org/mapdb/Volume.java
@@ -2893,7 +2893,7 @@ public abstract class Volume implements Closeable{
             try {
                 raf.seek(offset);
                 byte[] b = new byte[size];
-                raf.read(b);
+                raf.readFully(b);
                 return new DataIO.DataInputByteArray(b);
             } catch (IOException e) {
                 throw new DBException.VolumeIOError(e);
@@ -2904,7 +2904,7 @@ public abstract class Volume implements Closeable{
         public synchronized void getData(long offset, byte[] bytes, int bytesPos, int size) {
             try {
                 raf.seek(offset);
-                raf.read(bytes,bytesPos,size);
+                raf.readFully(bytes,bytesPos,size);
             } catch (IOException e) {
                 throw new DBException.VolumeIOError(e);
             }


### PR DESCRIPTION
RAF.read(byte[]) isn't guaranteed to read the entire buffer. It may read less, and return the result. Use readFully to make sure to read the entire buffer.

Similarly with FileInputStream.skip. It may not skip the entire requested size, add a skipFully method to DataIO to do so.