### PR TITLE
allow multiple calls to TxMaker.close()

### DIFF
--- a/src/main/java/org/mapdb/TxMaker.java
+++ b/src/main/java/org/mapdb/TxMaker.java
@@ -69,9 +69,11 @@ public class TxMaker implements Closeable {
         return new DB(snapshot,strictDBGet,false,executor, true, null, 0, null, null, serializerClassLoader);
     }
 
-    public void close() {
-        engine.close();
-        engine = null;
+    public synchronized void close() {
+        if (engine != null) {
+            engine.close();
+            engine = null;
+        }
     }
 
     /**

--- a/src/test/java/org/mapdb/TxMakerTest.java
+++ b/src/test/java/org/mapdb/TxMakerTest.java
@@ -397,4 +397,9 @@ public class TxMakerTest{
 
         txMaker.close();
     }
+
+    @Test public void testDuplicateClose() {
+        tx.close();
+        tx.close();
+    }
 }


### PR DESCRIPTION
Currently, a second call to TxMaker.close() leads to an NPE. This is in violation of the contract for Closeable.close() (https://docs.oracle.com/javase/8/docs/api/java/io/Closeable.html#close--), which specifies that "If the stream is already closed then invoking this method has no effect."