### PR TITLE
avoid npe if either lo or high is null

### DIFF
--- a/src/main/java/org/mapdb/BTreeMap.java
+++ b/src/main/java/org/mapdb/BTreeMap.java
@@ -3387,7 +3387,7 @@ public class BTreeMap<K,V>
 
         @Override
         public ConcurrentNavigableMap<K,V> descendingMap() {
-            if(lo==null && hi==null) return m;
+            if(lo==null || hi==null) return m;
             return m.subMap(lo,loInclusive,hi,hiInclusive);
         }
 


### PR DESCRIPTION
subMap requires both lo and high to be non null, so change the guard from and to or.