### PR TITLE
add constraints for BTree keys to ensure that they are Comparable

### DIFF
--- a/src/main/java/org/mapdb/DB.java
+++ b/src/main/java/org/mapdb/DB.java
@@ -1445,10 +1445,16 @@ public class DB implements Closeable {
         return treeMap(name,(BTreeKeySerializer)null,null);
     }
 
-    synchronized public <K,V> BTreeMap<K,V> treeMap(String name, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+    synchronized public <K extends Comparable<? super K>,V> BTreeMap<K,V> treeMap(String name, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
         if(keySerializer==null)
             keySerializer = getDefaultSerializer();
         return treeMap(name,keySerializer.getBTreeKeySerializer(null),valueSerializer);
+    }
+
+    synchronized public <K,V> BTreeMap<K,V> treeMap(String name, Serializer<K> keySerializer, Serializer<V> valueSerializer, Comparator<K> keyComparator) {
+        if(keySerializer==null)
+            keySerializer = getDefaultSerializer();
+        return treeMap(name,keySerializer.getBTreeKeySerializer(keyComparator),valueSerializer);
     }
 
     synchronized public <K,V> BTreeMap<K,V> treeMap(String name, BTreeKeySerializer keySerializer, Serializer<V> valueSerializer){


### PR DESCRIPTION
The intention is to make it impossible to run into runtime exceptions
due to not having a well-defined key ordering for BTreeMaps.

An example exception:
```
Caused by: java.lang.ClassCastException: com.spotify.gabofiletailer.AutoValue_FosMessage cannot be cast to java.lang.Comparable
	at org.mapdb.Fun$2.compare(Fun.java:59) ~[mapdb-2.0-beta8.jar:na]
	at org.mapdb.BTreeKeySerializer$BasicKeySerializer.compare(BTreeKeySerializer.java:221) ~[mapdb-2.0-beta8.jar:na]
	at org.mapdb.BTreeKeySerializer$BasicKeySerializer.compare(BTreeKeySerializer.java:171) ~[mapdb-2.0-beta8.jar:na]
	at org.mapdb.BTreeKeySerializer.findChildren2(BTreeKeySerializer.java:130) ~[mapdb-2.0-beta8.jar:na]
	at org.mapdb.BTreeMap.removeOrReplace(BTreeMap.java:1578) ~[mapdb-2.0-beta8.jar:na]
	at org.mapdb.BTreeMap.remove(BTreeMap.java:1550) ~[mapdb-2.0-beta8.jar:na]
```