### PR TITLE
add modification listeners that fire after locks have been released

### DIFF
--- a/src/main/java/org/mapdb/BTreeMap.java
+++ b/src/main/java/org/mapdb/BTreeMap.java
@@ -1155,6 +1155,7 @@ public class BTreeMap<K,V>
                     //$DELAY$
                     notify(key, (V) oldVal, value2);
                     unlock(nodeLocks, current);
+                    notifyAfter(key, (V) oldVal, value2);
                     //$DELAY$
                     if(CC.ASSERT)
                         assertNoLocks(nodeLocks);
@@ -1206,6 +1207,7 @@ public class BTreeMap<K,V>
                 notify(key,  null, value2);
                 //$DELAY$
                 unlock(nodeLocks, current);
+                notifyAfter(key,  null, value2);
                 if(CC.ASSERT) assertNoLocks(nodeLocks);
                 return null;
             }else{
@@ -1269,6 +1271,7 @@ public class BTreeMap<K,V>
                     //$DELAY$
                     unlock(nodeLocks, rootRecidRef);
                     //$DELAY$
+                    notifyAfter(key,  null, value2);
                     if(CC.ASSERT) assertNoLocks(nodeLocks);
                     //$DELAY$
                     return null;
@@ -1605,6 +1608,7 @@ public class BTreeMap<K,V>
 
                 notify((K)key, (V)oldVal, (V)putNewValue);
                 unlock(nodeLocks, current);
+                notifyAfter((K)key, (V)oldVal, (V)putNewValue);
                 return (V) oldVal;
             }else if(pos<=0 && -pos-1!=A.keysLen(keySerializer)-1){
                 //not found
@@ -3529,6 +3533,43 @@ public class BTreeMap<K,V>
             throw new AssertionError();
 
         Bind.MapListener<K,V>[] modListeners2  = modListeners;
+        for(Bind.MapListener<K,V> listener:modListeners2){
+            if(listener!=null)
+                listener.update(key, oldValue, newValue);
+        }
+    }
+    
+    protected final Object modAfterListenersLock = new Object();
+    protected Bind.MapListener<K,V>[] modAfterListeners = new Bind.MapListener[0];
+
+    @Override
+    public void modificationListenerAfterAdd(Bind.MapListener<K, V> listener) {
+        synchronized (modAfterListenersLock){
+            Bind.MapListener<K,V>[] modListeners2 =
+                    Arrays.copyOf(modAfterListeners,modAfterListeners.length+1);
+            modListeners2[modListeners2.length-1] = listener;
+            modAfterListeners = modListeners2;
+        }
+
+    }
+
+    @Override
+    public void modificationListenerAfterRemove(Bind.MapListener<K, V> listener) {
+        synchronized (modAfterListenersLock){
+            for(int i=0;i<modAfterListeners.length;i++){
+                if(modAfterListeners[i]==listener) modAfterListeners[i]=null;
+            }
+        }
+    }
+
+    //TODO check  references to notify
+    protected void notifyAfter(K key, V oldValue, V newValue) {
+        if(CC.ASSERT && ! (!(oldValue instanceof ValRef)))
+            throw new AssertionError();
+        if(CC.ASSERT && ! (!(newValue instanceof ValRef)))
+            throw new AssertionError();
+
+        Bind.MapListener<K,V>[] modListeners2  = modAfterListeners;
         for(Bind.MapListener<K,V> listener:modListeners2){
             if(listener!=null)
                 listener.update(key, oldValue, newValue);

--- a/src/main/java/org/mapdb/Bind.java
+++ b/src/main/java/org/mapdb/Bind.java
@@ -101,6 +101,19 @@ public final class Bind {
          * @param listener  callback interface notified when map changes
          */
         public void modificationListenerRemove(MapListener<K, V> listener);
+        
+        /**
+         * Add new modification listener notified after Map has been updated
+         * @param listener callback interface notified when map changes
+         */
+        public void modificationListenerAfterAdd(MapListener<K, V> listener);
+
+        /**
+         * Remove registered notification listener
+         *
+         * @param listener  callback interface notified when map changes
+         */
+        public void modificationListenerAfterRemove(MapListener<K, V> listener);
 
 
         /**

--- a/src/test/java/org/mapdb/MapListenerTest.java
+++ b/src/test/java/org/mapdb/MapListenerTest.java
@@ -12,15 +12,23 @@ import static org.junit.Assert.assertTrue;
 public class MapListenerTest {
 
         @Test public void hashMap(){
-            tt(DBMaker.memoryDB().transactionDisable().cacheHashTableEnable().make().hashMap("test"));
+            tt(DBMaker.memoryDB().transactionDisable().cacheHashTableEnable().make().hashMap("test"), false);
         }
 
         @Test public void treeMap(){
-            tt(DBMaker.memoryDB().transactionDisable().cacheHashTableEnable().make().treeMap("test"));
+            tt(DBMaker.memoryDB().transactionDisable().cacheHashTableEnable().make().treeMap("test"), false);
+        }
+        
+        @Test public void hashMapAfter(){
+            tt(DBMaker.memoryDB().transactionDisable().cacheHashTableEnable().make().hashMap("test"), true);
+        }
+
+        @Test public void treeMapAfter(){
+            tt(DBMaker.memoryDB().transactionDisable().cacheHashTableEnable().make().treeMap("test"), true);
         }
 
 
-        void tt(Bind.MapWithModificationListener m){
+        void tt(Bind.MapWithModificationListener m, boolean after){
             final AtomicReference key = new AtomicReference(null);
             final AtomicReference newVal = new AtomicReference(null);
             final AtomicReference oldVal = new AtomicReference(null);
@@ -35,7 +43,12 @@ public class MapListenerTest {
                 }
             };
 
-            m.modificationListenerAdd(listener);
+            if (after){
+                m.modificationListenerAfterAdd(listener);
+            }else{
+                m.modificationListenerAdd(listener);
+            }
+            
 
             //check CRUD
             m.put("aa","bb");
@@ -47,18 +60,23 @@ public class MapListenerTest {
             m.remove("aa");
             assertTrue(key.get()=="aa" && newVal.get()==null && oldVal.get()=="cc" && counter.get()==3);
 
-            //check clear()
-            m.put("aa","bb");
-            assertTrue(key.get()=="aa" && newVal.get()=="bb" && oldVal.get()==null && counter.get()==4);
-            m.clear();
-            assertTrue(key.get()=="aa" && newVal.get()==null && oldVal.get()=="bb" && counter.get()==5);
-
+            if (!after){
+                //check clear()
+                m.put("aa","bb");
+                assertTrue(key.get()=="aa" && newVal.get()=="bb" && oldVal.get()==null && counter.get()==4);
+                m.clear();
+                assertTrue(key.get()=="aa" && newVal.get()==null && oldVal.get()=="bb" && counter.get()==5);
+            }
 
             //check it was unregistered
             counter.set(0);
-            m.modificationListenerRemove(listener);
+            if (after){
+                m.modificationListenerAfterRemove(listener);
+            }else{
+                m.modificationListenerRemove(listener);
+            }
             m.put("aa","bb");
             assertEquals(0, counter.get());
-    }
+        }
 
 }

--- a/src/test/java/org/mapdb/issues/Issue607Test.java
+++ b/src/test/java/org/mapdb/issues/Issue607Test.java
@@ -1,0 +1,26 @@
+package org.mapdb.issues;
+
+import org.junit.Test;
+import org.mapdb.Bind.MapListener;
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.mapdb.HTreeMap;
+
+public class Issue607Test {
+
+    @Test
+    public void testListenerDeadlock() {
+        final DB db = DBMaker.memoryDB().make();
+        final HTreeMap<Object,Object> map = db.hashMap("test");
+        map.modificationListenerAfterAdd(new MapListener<Object, Object>() {
+            @Override
+            public void update(Object key, Object oldVal, Object newVal) {
+                if ("foo".equals(newVal)) {
+                    map.put("xyz", "bar");
+                }
+                db.commit();
+            }
+        });
+        map.put("abc", "foo");
+    }
+}


### PR DESCRIPTION
This commit adds listeners that fire after the modification has been made, after the locks have been released.

They don't support clear() right now - it would require to keep a copy of all the items being cleared to queue them up and send notifications. I thought this would be very taxing performance-wise.

See #607 for discussion.