### PR TITLE
Code Quality Fix - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/src/main/java/org/mapdb/DBException.java
+++ b/src/main/java/org/mapdb/DBException.java
@@ -95,7 +95,7 @@ public class DBException extends RuntimeException{
     public static class OutOfMemory extends VolumeIOError{
         public OutOfMemory(Throwable e){
             super(
-                    e.getMessage().equals("Direct buffer memory")?
+                    "Direct buffer memory".equals(e.getMessage())?
                             "Out of Direct buffer memory. Increase it with JVM option '-XX:MaxDirectMemorySize=10G'":
                             e.getMessage(),
                     e);

--- a/src/test/java/org/mapdb/BTreeMapTest5.java
+++ b/src/test/java/org/mapdb/BTreeMapTest5.java
@@ -245,11 +245,11 @@ public class BTreeMapTest5 extends JSR166TestCase {
         while (it.hasNext()) {
             Map.Entry e = (Map.Entry) it.next();
             assertTrue(
-                    (e.getKey().equals(one) && e.getValue().equals("A")) ||
-                            (e.getKey().equals(two) && e.getValue().equals("B")) ||
-                            (e.getKey().equals(three) && e.getValue().equals("C")) ||
-                            (e.getKey().equals(four) && e.getValue().equals("D")) ||
-                            (e.getKey().equals(five) && e.getValue().equals("E")));
+                    (e.getKey().equals(one) && "A".equals(e.getValue())) ||
+                            (e.getKey().equals(two) && "B".equals(e.getValue())) ||
+                            (e.getKey().equals(three) && "C".equals(e.getValue())) ||
+                            (e.getKey().equals(four) && "D".equals(e.getValue())) ||
+                            (e.getKey().equals(five) && "E".equals(e.getValue())));
         }
     }
 
@@ -919,11 +919,11 @@ public class BTreeMapTest5 extends JSR166TestCase {
         while (it.hasNext()) {
             Map.Entry e = (Map.Entry) it.next();
             assertTrue(
-                    (e.getKey().equals(m1) && e.getValue().equals("A")) ||
-                            (e.getKey().equals(m2) && e.getValue().equals("B")) ||
-                            (e.getKey().equals(m3) && e.getValue().equals("C")) ||
-                            (e.getKey().equals(m4) && e.getValue().equals("D")) ||
-                            (e.getKey().equals(m5) && e.getValue().equals("E")));
+                    (e.getKey().equals(m1) && "A".equals(e.getValue())) ||
+                            (e.getKey().equals(m2) && "B".equals(e.getValue())) ||
+                            (e.getKey().equals(m3) && "C".equals(e.getValue())) ||
+                            (e.getKey().equals(m4) && "D".equals(e.getValue())) ||
+                            (e.getKey().equals(m5) && "E".equals(e.getValue())));
         }
     }
 

--- a/src/test/java/org/mapdb/BTreeMapTest6.java
+++ b/src/test/java/org/mapdb/BTreeMapTest6.java
@@ -281,11 +281,11 @@ public class BTreeMapTest6 extends JSR166TestCase {
         while (it.hasNext()) {
             Map.Entry e = (Map.Entry) it.next();
             assertTrue(
-                    (e.getKey().equals(one) && e.getValue().equals("A")) ||
-                            (e.getKey().equals(two) && e.getValue().equals("B")) ||
-                            (e.getKey().equals(three) && e.getValue().equals("C")) ||
-                            (e.getKey().equals(four) && e.getValue().equals("D")) ||
-                            (e.getKey().equals(five) && e.getValue().equals("E")));
+                    (e.getKey().equals(one) && "A".equals(e.getValue())) ||
+                            (e.getKey().equals(two) && "B".equals(e.getValue())) ||
+                            (e.getKey().equals(three) && "C".equals(e.getValue())) ||
+                            (e.getKey().equals(four) && "D".equals(e.getValue())) ||
+                            (e.getKey().equals(five) && "E".equals(e.getValue())));
         }
     }
 
@@ -300,11 +300,11 @@ public class BTreeMapTest6 extends JSR166TestCase {
         while (it.hasNext()) {
             Map.Entry e = (Map.Entry) it.next();
             assertTrue(
-                    (e.getKey().equals(one) && e.getValue().equals("A")) ||
-                            (e.getKey().equals(two) && e.getValue().equals("B")) ||
-                            (e.getKey().equals(three) && e.getValue().equals("C")) ||
-                            (e.getKey().equals(four) && e.getValue().equals("D")) ||
-                            (e.getKey().equals(five) && e.getValue().equals("E")));
+                    (e.getKey().equals(one) && "A".equals(e.getValue())) ||
+                            (e.getKey().equals(two) && "B".equals(e.getValue())) ||
+                            (e.getKey().equals(three) && "C".equals(e.getValue())) ||
+                            (e.getKey().equals(four) && "D".equals(e.getValue())) ||
+                            (e.getKey().equals(five) && "E".equals(e.getValue())));
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Christian Ivan