### PR TITLE
Code quality fix - Format string should use %n rather than \n

### DIFF
--- a/src/test/java/examples/CacheOffHeap.java
+++ b/src/test/java/examples/CacheOffHeap.java
@@ -48,7 +48,7 @@ public class CacheOffHeap {
             cache.put(key,value);
 
             if(counter%1e5==0){
-                System.out.printf("Map size: %,d, counter %,d, store size: %,d, store free size: %,d\n",
+                System.out.printf("Map size: %,d, counter %,d, store size: %,d, store free size: %,d%n",
                         cache.sizeLong(), counter, store.getCurrSize(),  store.getFreeSize());
             }
 

--- a/src/test/java/examples/CacheOffHeapAdvanced.java
+++ b/src/test/java/examples/CacheOffHeapAdvanced.java
@@ -58,7 +58,7 @@ public class CacheOffHeapAdvanced {
             cache.put(key,value);
 
             if(counter%1e5==0){
-                System.out.printf("Map size: %,d, counter %,d, curr store size: %,d, store free size: %,d\n",
+                System.out.printf("Map size: %,d, counter %,d, curr store size: %,d, store free size: %,d%n",
                         cache.sizeLong(), counter, store.getCurrSize(),  store.getFreeSize());
             }
 

--- a/src/test/java/org/mapdb/issues/Issue148Test.java
+++ b/src/test/java/org/mapdb/issues/Issue148Test.java
@@ -104,7 +104,7 @@ public class Issue148Test {
 
         for( String key : keyset ){
             CustomValue cv = users.get(key);
-            System.out.format("%s(%b) : %d\n", key, key.equals(cv.name), cv.age);
+            System.out.format("%s(%b) : %d%n", key, key.equals(cv.name), cv.age);
         }
 
         System.out.println("");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule findbugs:VA_FORMAT_STRING_USES_NEWLINE - “Format string should use %n rather than \n”.
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/findbugs:VA_FORMAT_STRING_USES_NEWLINE

Please let me know if you have any questions.

Christian Ivan