### PR TITLE
Code quality fix - NullPointerException should not be explicitly thrown

### DIFF
--- a/src/main/java/org/mapdb/BTreeKeySerializer.java
+++ b/src/main/java/org/mapdb/BTreeKeySerializer.java
@@ -177,7 +177,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
 
         public BasicKeySerializer(Serializer serializer, Comparator comparator) {
             if(serializer == null || comparator == null)
-                throw new  NullPointerException();
+                throw new IllegalArgumentException("serializer or comparator is null");
             this.serializer = serializer;
             this.comparator = comparator;
         }
@@ -188,7 +188,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
             serializer = (Serializer) serializerBase.deserialize(is,objectStack);
             comparator = (Comparator) serializerBase.deserialize(is,objectStack);
             if(serializer == null || comparator == null)
-                throw new  NullPointerException();
+                throw new IllegalArgumentException("serializer or comparator is null");
         }
 
         @Override
@@ -2021,7 +2021,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
 
         public Compress(BTreeKeySerializer wrapped) {
             if(wrapped == null)
-                throw new  NullPointerException();
+                throw new IllegalArgumentException("wrapped = NULL");
 
             this.wrapped = wrapped;
         }
@@ -2030,7 +2030,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
             objectStack.add(this);
             wrapped = (BTreeKeySerializer) serializerBase.deserialize(in,objectStack);
             if(wrapped == null)
-                throw new  NullPointerException();
+                throw new IllegalArgumentException("wrapped = NULL");
         }
 
         @Override

--- a/src/main/java/org/mapdb/BTreeMap.java
+++ b/src/main/java/org/mapdb/BTreeMap.java
@@ -768,7 +768,7 @@ public class BTreeMap<K,V>
 
         public NodeSerializer(boolean valsOutsideNodes, BTreeKeySerializer keySerializer, Serializer valueSerializer,  int numberOfNodeMetas) {
             if(keySerializer==null)
-                throw new NullPointerException("keySerializer not set");
+                throw new IllegalArgumentException("keySerializer is not set");
             this.hasValues = valueSerializer!=null;
             this.valsOutsideNodes = valsOutsideNodes;
             this.keySerializer = keySerializer;
@@ -945,7 +945,7 @@ public class BTreeMap<K,V>
         if(rootRecidRef<=0||counterRecid<0 || numberOfNodeMetas<0)
             throw new IllegalArgumentException();
         if(keySerializer==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("keySerializer is not set");
 
         this.rootRecidRef = rootRecidRef;
         this.hasValues = valueSerializer!=null;
@@ -1014,7 +1014,7 @@ public class BTreeMap<K,V>
     }
 
     protected Object get(Object key, boolean expandValue) {
-        if(key==null) throw new NullPointerException();
+        if(key==null) throw new IllegalArgumentException("key = NULL");
         K v = (K) key;
         long current = engine.get(rootRecidRef, Serializer.RECID); //get root
         //$DELAY$
@@ -1075,7 +1075,7 @@ public class BTreeMap<K,V>
 
     @Override
     public V put(K key, V value){
-        if(key==null||value==null) throw new NullPointerException();
+        if(key==null||value==null) throw new IllegalArgumentException("key or value is null");
         return put2(key, value, false);
     }
 
@@ -1552,7 +1552,7 @@ public class BTreeMap<K,V>
 
     private V removeOrReplace(final Object key, final Object value, final  Object putNewValue) {
         if(key==null)
-            throw new NullPointerException("null key");
+            throw new IllegalArgumentException("key = NULL");
         long current = engine.get(rootRecidRef, Serializer.RECID);
 
         BNode A = engine.get(current, nodeSerializer);
@@ -1862,26 +1862,26 @@ public class BTreeMap<K,V>
 
     @Override
     public V putIfAbsent(K key, V value) {
-        if(key == null || value == null) throw new NullPointerException();
+        if(key == null || value == null) throw new IllegalArgumentException("key or value is null");
         return put2(key, value, true);
     }
 
     @Override
     public boolean remove(Object key, Object value) {
-        if(key == null) throw new NullPointerException();
+        if(key == null) throw new IllegalArgumentException("key = NULL");
         return value != null && removeOrReplace(key, value, null) != null;
     }
 
     @Override
     public boolean replace(final K key, final V oldValue, final V newValue) {
-        if(key == null || oldValue == null || newValue == null ) throw new NullPointerException();
+        if(key == null || oldValue == null || newValue == null ) throw new IllegalArgumentException("key, oldValue, or newValue is null");
 
         return removeOrReplace(key,oldValue,newValue)!=null;
     }
 
     @Override
     public V replace(final K key, final V value) {
-        if(key == null || value == null) throw new NullPointerException();
+        if(key == null || value == null) throw new IllegalArgumentException("key or value is null");
 
         return removeOrReplace(key, null, value);
     }
@@ -1963,7 +1963,7 @@ public class BTreeMap<K,V>
 
 
     protected Entry<K,V> findSmaller(K key,boolean inclusive){
-        if(key==null) throw new NullPointerException();
+        if(key==null) throw new IllegalArgumentException("key = NULL");
         final long rootRecid = engine.get(rootRecidRef, Serializer.RECID);
         //$DELAY$
         BNode n = engine.get(rootRecid, nodeSerializer);
@@ -2015,7 +2015,7 @@ public class BTreeMap<K,V>
 
     protected Fun.Pair<Integer,BNode> findSmallerNode(K key,boolean inclusive){
         if(key==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("key = NULL");
         final long rootRecid = engine.get(rootRecidRef, Serializer.RECID);
         //$DELAY$
         BNode n = engine.get(rootRecid, nodeSerializer);
@@ -2086,7 +2086,7 @@ public class BTreeMap<K,V>
                     return ret;
             }
 
-            //iterate over keys to find last non null key
+            //iterate over keys to find last non key = NULL
             for(int i=n.keysLen(keySerializer)-2; i>0;i--){
                 Object k = n.key(keySerializer,i);
                 if(k!=null && n.valSize(valueNodeSerializer)>0) {
@@ -2116,7 +2116,7 @@ public class BTreeMap<K,V>
 
     @Override
 	public Map.Entry<K,V> lowerEntry(K key) {
-        if(key==null) throw new NullPointerException();
+        if(key==null) throw new IllegalArgumentException("key = NULL");
         return findSmaller(key, false);
     }
 
@@ -2128,7 +2128,7 @@ public class BTreeMap<K,V>
 
     @Override
 	public Map.Entry<K,V> floorEntry(K key) {
-        if(key==null) throw new NullPointerException();
+        if(key==null) throw new IllegalArgumentException("key = NULL");
         return findSmaller(key, true);
     }
 
@@ -2140,7 +2140,7 @@ public class BTreeMap<K,V>
 
     @Override
 	public Map.Entry<K,V> ceilingEntry(K key) {
-        if(key==null) throw new NullPointerException();
+        if(key==null) throw new IllegalArgumentException("key = NULL");
         return findLarger(key, true);
     }
 
@@ -2219,33 +2219,33 @@ public class BTreeMap<K,V>
 
     @Override
 	public K ceilingKey(K key) {
-        if(key==null) throw new NullPointerException();
+        if(key==null) throw new IllegalArgumentException("key = NULL");
         Entry<K,V> n = ceilingEntry(key);
         return (n == null)? null : n.getKey();
     }
 
     @Override
 	public Map.Entry<K,V> higherEntry(K key) {
-        if(key==null) throw new NullPointerException();
+        if(key==null) throw new IllegalArgumentException("key = NULL");
         return findLarger(key, false);
     }
 
     @Override
 	public K higherKey(K key) {
-        if(key==null) throw new NullPointerException();
+        if(key==null) throw new IllegalArgumentException("key = NULL");
         Entry<K,V> n = higherEntry(key);
         return (n == null)? null : n.getKey();
     }
 
     @Override
     public boolean containsKey(Object key) {
-        if(key==null) throw new NullPointerException();
+        if(key==null) throw new IllegalArgumentException("key = NULL");
         return get(key, false)!=null;
     }
 
     @Override
     public boolean containsValue(Object value){
-        if(value ==null) throw new NullPointerException();
+        if(value ==null) throw new IllegalArgumentException("value = NULL");
         Iterator<V> valueIter = valueIterator();
         //$DELAY$
         while(valueIter.hasNext()){
@@ -2272,7 +2272,7 @@ public class BTreeMap<K,V>
                                               K toKey,
                                               boolean toInclusive) {
         if (fromKey == null || toKey == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("fromKey or toKey is null");
         return new SubMap<K,V>
                 ( this, fromKey, fromInclusive, toKey, toInclusive);
     }
@@ -2281,7 +2281,7 @@ public class BTreeMap<K,V>
     public ConcurrentNavigableMap<K,V> headMap(K toKey,
                                                boolean inclusive) {
         if (toKey == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("toKey is null");
         return new SubMap<K,V>
                 (this, null, false, toKey, inclusive);
     }
@@ -2290,7 +2290,7 @@ public class BTreeMap<K,V>
     public ConcurrentNavigableMap<K,V> tailMap(K fromKey,
                                                boolean inclusive) {
         if (fromKey == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("fromKey is null");
         return new SubMap<K,V>
                 (this, fromKey, inclusive, null, false);
     }
@@ -2644,14 +2644,14 @@ public class BTreeMap<K,V>
 
         @Override
 		public boolean containsKey(Object key) {
-            if (key == null) throw new NullPointerException();
+            if (key == null) throw new IllegalArgumentException("key = NULL");
             K k = (K)key;
             return inBounds(k) && m.containsKey(k);
         }
 
         @Override
 		public V get(Object key) {
-            if (key == null) throw new NullPointerException();
+            if (key == null) throw new IllegalArgumentException("key = NULL");
             K k = (K)key;
             return ((!inBounds(k)) ? null : m.get(k));
         }
@@ -2665,7 +2665,7 @@ public class BTreeMap<K,V>
         @Override
 		public V remove(Object key) {
             if(key==null)
-                throw new NullPointerException("key null");
+                throw new IllegalArgumentException("key = NULL");
             K k = (K)key;
             return (!inBounds(k))? null : m.remove(k);
         }
@@ -2697,7 +2697,7 @@ public class BTreeMap<K,V>
 
         @Override
 		public boolean containsValue(Object value) {
-            if(value==null) throw new NullPointerException();
+            if(value==null) throw new IllegalArgumentException("value = NULL");
             Iterator<V> i = valueIterator();
             while(i.hasNext()){
                 if(m.valueSerializer.equals((V)value,i.next()))
@@ -2753,7 +2753,7 @@ public class BTreeMap<K,V>
 
         @Override
 		public Map.Entry<K,V> lowerEntry(K key) {
-            if(key==null)throw new NullPointerException();
+            if(key==null)throw new IllegalArgumentException("key = NULL");
             if(tooLow(key))return null;
 
             if(tooHigh(key))
@@ -2771,7 +2771,7 @@ public class BTreeMap<K,V>
 
         @Override
 		public Map.Entry<K,V> floorEntry(K key) {
-            if(key==null) throw new NullPointerException();
+            if(key==null) throw new IllegalArgumentException("key = NULL");
             if(tooLow(key)) return null;
 
             if(tooHigh(key)){
@@ -2792,7 +2792,7 @@ public class BTreeMap<K,V>
 
         @Override
 		public Map.Entry<K,V> ceilingEntry(K key) {
-            if(key==null) throw new NullPointerException();
+            if(key==null) throw new IllegalArgumentException("key = NULL");
             if(tooHigh(key)) return null;
 
             if(tooLow(key)){
@@ -2928,7 +2928,7 @@ public class BTreeMap<K,V>
                                   K toKey,
                                   boolean toInclusive) {
             if (fromKey == null || toKey == null)
-                throw new NullPointerException();
+                throw new IllegalArgumentException("fromKey or toKey is null");
             return newSubMap(fromKey, fromInclusive, toKey, toInclusive);
         }
 
@@ -2936,7 +2936,7 @@ public class BTreeMap<K,V>
 		public SubMap<K,V> headMap(K toKey,
                                    boolean inclusive) {
             if (toKey == null)
-                throw new NullPointerException();
+                throw new IllegalArgumentException("toKey = NULL");
             return newSubMap(null, false, toKey, inclusive);
         }
 
@@ -2944,7 +2944,7 @@ public class BTreeMap<K,V>
 		public SubMap<K,V> tailMap(K fromKey,
                                    boolean inclusive) {
             if (fromKey == null)
-                throw new NullPointerException();
+                throw new IllegalArgumentException("fromKey = NULL");
             return newSubMap(fromKey, inclusive, null, false);
         }
 
@@ -3002,7 +3002,7 @@ public class BTreeMap<K,V>
 
         private void checkKeyBounds(K key) throws IllegalArgumentException {
             if (key == null)
-                throw new NullPointerException();
+                throw new IllegalArgumentException("key = NULL");
             if (!inBounds(key))
                 throw new IllegalArgumentException("key out of range");
         }
@@ -3073,14 +3073,14 @@ public class BTreeMap<K,V>
 
         @Override
         public boolean containsKey(Object key) {
-            if (key == null) throw new NullPointerException();
+            if (key == null) throw new IllegalArgumentException("key = NULL");
             K k = (K)key;
             return inBounds(k) && m.containsKey(k);
         }
 
         @Override
         public V get(Object key) {
-            if (key == null) throw new NullPointerException();
+            if (key == null) throw new IllegalArgumentException("key = NULL");
             K k = (K)key;
             return ((!inBounds(k)) ? null : m.get(k));
         }
@@ -3118,7 +3118,7 @@ public class BTreeMap<K,V>
 
         @Override
         public boolean containsValue(Object value) {
-            if(value==null) throw new NullPointerException();
+            if(value==null) throw new IllegalArgumentException("value = NULL");
             Iterator<V> i = valueIterator();
             while(i.hasNext()){
                 if(m.valueSerializer.equals((V) value,i.next()))
@@ -3174,7 +3174,7 @@ public class BTreeMap<K,V>
 
         @Override
         public Map.Entry<K,V> higherEntry(K key) {
-            if(key==null)throw new NullPointerException();
+            if(key==null)throw new IllegalArgumentException("key = NULL");
             if(tooLow(key))return null;
 
             if(tooHigh(key))
@@ -3192,7 +3192,7 @@ public class BTreeMap<K,V>
 
         @Override
         public Map.Entry<K,V> ceilingEntry(K key) {
-            if(key==null) throw new NullPointerException();
+            if(key==null) throw new IllegalArgumentException("key = NULL");
             if(tooLow(key)) return null;
 
             if(tooHigh(key)){
@@ -3213,7 +3213,7 @@ public class BTreeMap<K,V>
 
         @Override
         public Map.Entry<K,V> floorEntry(K key) {
-            if(key==null) throw new NullPointerException();
+            if(key==null) throw new IllegalArgumentException("key = NULL");
             if(tooHigh(key)) return null;
 
             if(tooLow(key)){
@@ -3350,7 +3350,7 @@ public class BTreeMap<K,V>
                                   K toKey,
                                   boolean toInclusive) {
             if (fromKey == null || toKey == null)
-                throw new NullPointerException();
+                throw new IllegalArgumentException("fromKey or toKey is null");
             return newSubMap(fromKey, fromInclusive, toKey, toInclusive);
         }
 
@@ -3358,7 +3358,7 @@ public class BTreeMap<K,V>
         public DescendingMap<K,V> headMap(K toKey,
                                    boolean inclusive) {
             if (toKey == null)
-                throw new NullPointerException();
+                throw new IllegalArgumentException("toKey = NULL");
             return newSubMap(null, false, toKey, inclusive);
         }
 
@@ -3366,7 +3366,7 @@ public class BTreeMap<K,V>
         public DescendingMap<K,V> tailMap(K fromKey,
                                    boolean inclusive) {
             if (fromKey == null)
-                throw new NullPointerException();
+                throw new IllegalArgumentException("fromKey = NULL");
             return newSubMap(fromKey, inclusive, null, false);
         }
 
@@ -3425,7 +3425,7 @@ public class BTreeMap<K,V>
 
         private void checkKeyBounds(K key) throws IllegalArgumentException {
             if (key == null)
-                throw new NullPointerException();
+                throw new IllegalArgumentException("key = NULL");
             if (!inBounds(key))
                 throw new IllegalArgumentException("key out of range");
         }

--- a/src/main/java/org/mapdb/HTreeMap.java
+++ b/src/main/java/org/mapdb/HTreeMap.java
@@ -328,13 +328,13 @@ public class HTreeMap<K,V>
         if(counterRecids!=null && counterRecids.length!=SEG)
             throw new IllegalArgumentException();
         if(engines==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("engines is not set");
         if(engines.length!=SEG)
             throw new IllegalArgumentException("engines wrong length");
         if(segmentRecids==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("segmentRecids is not set");
         if(keySerializer==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("keySerializer is not set");
 
         this.hasValues = valueSerializer!=null;
 
@@ -868,10 +868,10 @@ public class HTreeMap<K,V>
     @Override
     public V put(final K key, final V value){
         if (key == null)
-            throw new IllegalArgumentException("null key");
+            throw new IllegalArgumentException("key = NULL");
 
         if (value == null)
-            throw new IllegalArgumentException("null value");
+            throw new IllegalArgumentException("value = NULL");
 
         V ret;
         final int h = hash(key);
@@ -1398,7 +1398,7 @@ public class HTreeMap<K,V>
         public boolean add(Entry<K, V> kvEntry) {
             K key = kvEntry.getKey();
             V value = kvEntry.getValue();
-            if(key==null || value == null) throw new NullPointerException();
+            if(key==null || value == null) throw new IllegalArgumentException("key or value is null");
             HTreeMap.this.put(key, value);
             return true;
         }
@@ -1670,7 +1670,7 @@ public class HTreeMap<K,V>
     @Override
     public V putIfAbsent(K key, V value) {
         if(key==null||value==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("key or value is null");
 
         final int h = HTreeMap.this.hash(key);
         final int segment = h >>>28;
@@ -1703,7 +1703,7 @@ public class HTreeMap<K,V>
     @Override
     public boolean remove(Object key, Object value) {
         if(key==null||value==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("key or value is null");
 
         boolean ret;
 
@@ -1735,7 +1735,7 @@ public class HTreeMap<K,V>
     @Override
     public boolean replace(K key, V oldValue, V newValue) {
         if(key==null||oldValue==null||newValue==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("key, oldValue, or newValue is null");
 
         boolean ret;
 
@@ -1767,7 +1767,7 @@ public class HTreeMap<K,V>
     @Override
     public V replace(K key, V value) {
         if(key==null||value==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("key or value is null");
         V ret;
         final int h = HTreeMap.this.hash(key);
         final int segment =  h >>>28;

--- a/src/main/java/org/mapdb/LongConcurrentHashMap.java
+++ b/src/main/java/org/mapdb/LongConcurrentHashMap.java
@@ -707,11 +707,11 @@ class LongConcurrentHashMap< V>
      * @param value value whose presence in this map is to be tested
      * @return <tt>true</tt> if this map maps one or more keys to the
      *         specified value
-     * @throws NullPointerException if the specified value is null
+     * @throws IllegalArgumentException if the specified value is null
      */
     public boolean containsValue(Object value) {
         if (value == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("value = NULL");
 
         // See explanation of modCount use above
 
@@ -769,12 +769,12 @@ class LongConcurrentHashMap< V>
      * @param value value to be associated with the specified key
      * @return the previous value associated with <tt>key</tt>, or
      *         <tt>null</tt> if there was no mapping for <tt>key</tt>
-     * @throws NullPointerException if the specified key or value is null
+     * @throws IllegalArgumentException if the specified key or value is null
      */
     
     public V put(long key, V value) {
         if (value == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("value = NULL");
         final int hash = DataIO.longHash(key ^ hashSalt);
         return segmentFor(hash).put(key, hash, value, false);
     }
@@ -784,11 +784,11 @@ class LongConcurrentHashMap< V>
      *
      * @return the previous value associated with the specified key,
      *         or <tt>null</tt> if there was no mapping for the key
-     * @throws NullPointerException if the specified key or value is null
+     * @throws IllegalArgumentException if the specified key or value is null
      */
     public V putIfAbsent(long key, V value) {
         if (value == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("value = NULL");
         final int hash = DataIO.longHash(key ^ hashSalt);
         return segmentFor(hash).put(key, hash, value, true);
     }
@@ -822,11 +822,11 @@ class LongConcurrentHashMap< V>
     /**
      *
      *
-     * @throws NullPointerException if any of the arguments are null
+     * @throws IllegalArgumentException if any of the arguments are null
      */
     public boolean replace(long key, V oldValue, V newValue) {
         if (oldValue == null || newValue == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("oldValue or newValue is null");
         final int hash = DataIO.longHash(key ^ hashSalt);
         return segmentFor(hash).replace(key, hash, oldValue, newValue);
     }
@@ -836,11 +836,11 @@ class LongConcurrentHashMap< V>
      *
      * @return the previous value associated with the specified key,
      *         or <tt>null</tt> if there was no mapping for the key
-     * @throws NullPointerException if the specified key or value is null
+     * @throws IllegalArgumentException if the specified key or value is null
      */
     public V replace(long key, V value) {
         if (value == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("value = NULL");
         final int hash = DataIO.longHash(key ^ hashSalt);
         return segmentFor(hash).replace(key, hash, value);
     }

--- a/src/main/java/org/mapdb/Serializer.java
+++ b/src/main/java/org/mapdb/Serializer.java
@@ -2146,7 +2146,7 @@ public abstract class Serializer<A> {
 
         public Array(Serializer<T> serializer) {
             if(serializer==null)
-                throw new NullPointerException("null serializer");
+                throw new IllegalArgumentException("serializer = NULL");
             this.serializer = serializer;
         }
 

--- a/src/main/java/org/mapdb/SerializerBase.java
+++ b/src/main/java/org/mapdb/SerializerBase.java
@@ -79,7 +79,7 @@ public class SerializerBase extends Serializer<Object>{
 
         public DeserSerializer(Serializer serializer) {
             if(serializer==null)
-                throw new NullPointerException();
+                throw new IllegalArgumentException("serializer = NULL");
             this.serializer = serializer;
         }
 
@@ -168,7 +168,7 @@ public class SerializerBase extends Serializer<Object>{
 
         public SerHeaderSerializer(int header, Serializer serializer) {
             if(serializer==null)
-                throw new NullPointerException();
+                throw new IllegalArgumentException("serializer = NULL");
             this.header = (byte) header;
             this.serializer = serializer;
         }

--- a/src/main/java/org/mapdb/Store.java
+++ b/src/main/java/org/mapdb/Store.java
@@ -232,7 +232,7 @@ public abstract class Store implements Engine {
     @Override
     public <A> A get(long recid, Serializer<A> serializer) {
         if(serializer==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("serializer = NULL");
         if(closed)
             throw new IllegalAccessError("closed");
 
@@ -265,7 +265,7 @@ public abstract class Store implements Engine {
     @Override
     public <A> void update(long recid, A value, Serializer<A> serializer) {
         if(serializer==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("serializer = NULL");
         if(closed)
             throw new IllegalAccessError("closed");
 
@@ -517,7 +517,7 @@ public abstract class Store implements Engine {
     @Override
     public <A> boolean compareAndSwap(long recid, A expectedOldValue, A newValue, Serializer<A> serializer) {
         if(serializer==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("serializer = NULL");
         if(closed)
             throw new IllegalAccessError("closed");
 
@@ -554,7 +554,7 @@ public abstract class Store implements Engine {
     @Override
     public <A> void delete(long recid, Serializer<A> serializer) {
         if(serializer==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("serializer = NULL");
         if(closed)
             throw new IllegalAccessError("closed");
 

--- a/src/main/java/org/mapdb/StoreCached.java
+++ b/src/main/java/org/mapdb/StoreCached.java
@@ -481,7 +481,7 @@ public class StoreCached extends StoreDirect {
             LOG.log(Level.FINER, "REC DEL recid={0}, serializer={1}",new Object[]{recid,serializer});
 
         if (serializer == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("serializer = NULL");
         int lockPos = lockPos(recid);
 
         LongObjectObjectMap map = writeCache[lockPos];
@@ -495,7 +495,7 @@ public class StoreCached extends StoreDirect {
     @Override
     public <A> long put(A value, Serializer<A> serializer) {
         if (serializer == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("serializer = NULL");
 
         //TODO this causes double locking, merge two methods into single method
         long recid = preallocate();
@@ -510,7 +510,7 @@ public class StoreCached extends StoreDirect {
     @Override
     public <A> void update(long recid, A value, Serializer<A> serializer) {
         if (serializer == null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("serializer = NULL");
 
         if(CC.LOG_STORE_RECORD && LOG.isLoggable(Level.FINER))
             LOG.log(Level.FINER, "REC UPDATE recid={0}, value={1}, serializer={2}",new Object[]{recid,value, serializer});
@@ -538,7 +538,7 @@ public class StoreCached extends StoreDirect {
     @Override
     public <A> boolean compareAndSwap(long recid, A expectedOldValue, A newValue, Serializer<A> serializer) {
         if(serializer==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("serializer = NULL");
 
         //TODO binary CAS & serialize outside lock
         final int lockPos = lockPos(recid);

--- a/src/main/java/org/mapdb/StoreHeap.java
+++ b/src/main/java/org/mapdb/StoreHeap.java
@@ -75,7 +75,7 @@ public class StoreHeap extends Store{
     @Override
     public <A> void update(long recid, A value, Serializer<A> serializer) {
         if(serializer==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("serializer = NULL");
         if(closed)
             throw new IllegalAccessError("closed");
 
@@ -112,7 +112,7 @@ public class StoreHeap extends Store{
     @Override
     public <A> boolean compareAndSwap(long recid, A expectedOldValue, A newValue, Serializer<A> serializer) {
         if(serializer==null)
-            throw new NullPointerException();
+            throw new IllegalArgumentException("serializer = NULL");
         if(closed)
             throw new IllegalAccessError("closed");
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1695 - “NullPointerException should not be explicitly thrown”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1695.

Please let me know if you have any questions.

Christian Ivan