### PR TITLE
Code quality fix - Performance - Method invokes inefficient Number constructor; use static valueOf instead

### DIFF
--- a/src/main/java/org/mapdb/BTreeKeySerializer.java
+++ b/src/main/java/org/mapdb/BTreeKeySerializer.java
@@ -320,7 +320,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
 
         @Override
         public Long getKey(long[] keys, int pos) {
-            return new Long(keys[pos]);
+            return Long.valueOf(keys[pos]);
         }
 
         @Override
@@ -492,7 +492,7 @@ public abstract class BTreeKeySerializer<KEY,KEYS>{
 
         @Override
         public Integer getKey(int[] keys, int pos) {
-            return new Integer(keys[pos]);
+            return Integer.valueOf(keys[pos]);
         }
 
         @Override

--- a/src/main/java/org/mapdb/Serializer.java
+++ b/src/main/java/org/mapdb/Serializer.java
@@ -425,7 +425,7 @@ public abstract class Serializer<A> {
 
         @Override
         protected Long unpack(long l) {
-            return new Long(l);
+            return Long.valueOf(l);
         }
 
         @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule findbugs:DM_NUMBER_CTOR - “Performance - Method invokes inefficient Number constructor; use static valueOf instead”. 
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/findbugs:DM_NUMBER_CTOR

Please let me know if you have any questions.

Christian Ivan.