### PR TITLE
Code quality fix - Loggers should be "private static final" and should share a naming convention

### DIFF
--- a/src/main/java/org/mapdb/DB.java
+++ b/src/main/java/org/mapdb/DB.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 @SuppressWarnings("unchecked")
 public class DB implements Closeable {
 
-    protected static final Logger LOG = Logger.getLogger(DB.class.getName());
+    private static final Logger LOG = Logger.getLogger(DB.class.getName());
     public static final String METRICS_DATA_WRITE = "data.write";
     public static final String METRICS_RECORD_WRITE = "record.write";
     public static final String METRICS_DATA_READ = "data.read";

--- a/src/main/java/org/mapdb/DBMaker.java
+++ b/src/main/java/org/mapdb/DBMaker.java
@@ -49,7 +49,7 @@ import java.util.logging.Logger;
  */
 public final class DBMaker{
 
-    protected static final Logger LOG = Logger.getLogger(DBMaker.class.getName());
+	private static final Logger LOG = Logger.getLogger(DBMaker.class.getName());
 
     protected static final String TRUE = "true";
 

--- a/src/main/java/org/mapdb/HTreeMap.java
+++ b/src/main/java/org/mapdb/HTreeMap.java
@@ -50,7 +50,7 @@ public class HTreeMap<K,V>
         Bind.MapWithModificationListener<K,V>,
         Closeable, Serializable {
 
-    protected static final Logger LOG = Logger.getLogger(HTreeMap.class.getName());
+	private static final Logger LOG = Logger.getLogger(HTreeMap.class.getName());
 
     protected static final int BUCKET_OVERFLOW = 4;
 

--- a/src/main/java/org/mapdb/Store.java
+++ b/src/main/java/org/mapdb/Store.java
@@ -24,7 +24,7 @@ import java.util.zip.CRC32;
  */
 public abstract class Store implements Engine {
 
-    protected static final Logger LOG = Logger.getLogger(Store.class.getName());
+    private static final Logger LOG = Logger.getLogger(Store.class.getName());
 
     protected static final long FEAT_COMP_LZF = 64L-1L;
     protected static final long FEAT_ENC_XTEA = 64L-2L;

--- a/src/main/java/org/mapdb/UnsafeStuff.java
+++ b/src/main/java/org/mapdb/UnsafeStuff.java
@@ -28,8 +28,6 @@ import static org.mapdb.DataIO.PRIME64_5;
  */
 class UnsafeStuff {
 
-    static final Logger LOG = Logger.getLogger(UnsafeStuff.class.getName());
-
     static final sun.misc.Unsafe UNSAFE = getUnsafe();
 
     @SuppressWarnings("restriction")
@@ -48,6 +46,8 @@ class UnsafeStuff {
             return null;
         }
     }
+    
+	private static final Logger LOG = Logger.getLogger(UnsafeStuff.class.getName());
 
     private static final long BYTE_ARRAY_OFFSET;
     private static final int BYTE_ARRAY_SCALE;

--- a/src/main/java/org/mapdb/Volume.java
+++ b/src/main/java/org/mapdb/Volume.java
@@ -118,7 +118,7 @@ public abstract class Volume implements Closeable{
 
     private static final byte[] CLEAR = new byte[1024];
 
-    protected static final Logger LOG = Logger.getLogger(Volume.class.getName());
+    private static final Logger LOG = Logger.getLogger(Volume.class.getName());
 
     /**
      * If {@code sun.misc.Unsafe} is available it will use Volume based on Unsafe.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1312 - “Loggers should be "private static final" and should share a naming convention”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1312.

Please let me know if you have any questions.

Christian Ivan