### PR TITLE
Code quality fix - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/org/mapdb/Pump.java
+++ b/src/main/java/org/mapdb/Pump.java
@@ -512,7 +512,7 @@ public final class Pump {
             lastLeafRecid = engine.put(leaf,nodeSerializer);
 
             //handle case when there is only single leaf and no dirs, in that case it will become root
-            if(isLeftMost && dirKeys.get(0).size()==0){
+            if(isLeftMost && dirKeys.get(0).isEmpty()){
                 rootRecid = lastLeafRecid;
                 break SOURCE_LOOP;
             }

--- a/src/test/java/org/mapdb/BTreeMapTest4.java
+++ b/src/test/java/org/mapdb/BTreeMapTest4.java
@@ -1872,7 +1872,7 @@ public class BTreeMapTest4 extends junit.framework.TestCase {
     public void test_empty_subMap() throws Exception {
         BTreeMap<Float, List<Integer>> tm = newBTreeMap();
         SortedMap<Float, List<Integer>> sm = tm.tailMap(1.1f);
-        assertTrue(sm.values().size() == 0);
+        assertTrue(sm.values().isEmpty());
     }
     
 

--- a/src/test/java/org/mapdb/BTreeMapTest6.java
+++ b/src/test/java/org/mapdb/BTreeMapTest6.java
@@ -1247,7 +1247,7 @@ public class BTreeMapTest6 extends JSR166TestCase {
         }
 
         // Test extrema
-        if (map.size() != 0) {
+        if (!map.isEmpty()) {
             assertEq(map.firstKey(), rs.first());
             assertEq(map.lastKey(), rs.last());
         } else {

--- a/src/test/java/org/mapdb/BTreeSet2Test.java
+++ b/src/test/java/org/mapdb/BTreeSet2Test.java
@@ -958,7 +958,7 @@ public class BTreeSet2Test extends JSR166TestCase {
         }
 
         // Test extrema
-        if (set.size() != 0) {
+        if (!set.isEmpty()) {
             assertEq(set.first(), rs.first());
             assertEq(set.last(), rs.last());
         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Christian Ivan.