### PR TITLE
Code quality fix - Empty arrays and collections should be returned instead of null

### DIFF
--- a/src/main/java/org/mapdb/HTreeMap.java
+++ b/src/main/java/org/mapdb/HTreeMap.java
@@ -1502,7 +1502,7 @@ public class HTreeMap<K,V>
                         }else
                             lastHash +=1;
                         if(lastHash==0){
-                            return null;
+                            return new LinkedNode[0];
                         }
                         break;
                     }
@@ -1545,13 +1545,13 @@ public class HTreeMap<K,V>
                 }
             }
 
-            return null;
+            return new LinkedNode[0];
         }
 
         private LinkedNode[] findNextLinkedNodeRecur(Engine engine,long dirRecid, int newHash, int level){
             final Object dir = engine.get(dirRecid, DIR_SERIALIZER);
             if(dir == null)
-                return null;
+                return new LinkedNode[0];
             int offset = Math.abs(
                     dirOffsetFromSlot(dir,
                             (newHash >>> (level * 7)) & 0x7F));
@@ -1590,7 +1590,7 @@ public class HTreeMap<K,V>
                 first = false;
                 offset+=1;
             }
-            return null;
+            return new LinkedNode[0];
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1168 - “Empty arrays and collections should be returned instead of null”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1168.

Please let me know if you have any questions.

Christian Ivan.