### PR TITLE
Code quality fix - static final arrays should be "private"

### DIFF
--- a/src/main/java/org/mapdb/StoreAppend.java
+++ b/src/main/java/org/mapdb/StoreAppend.java
@@ -25,7 +25,7 @@ public class StoreAppend extends Store {
 
     protected static final long headerSize = 16;
 
-    protected static final StoreAppend[] STORE_APPENDS_ZERO_ARRAY = new StoreAppend[0];
+    private static final StoreAppend[] STORE_APPENDS_ZERO_ARRAY = new StoreAppend[0];
 
 
     protected WriteAheadLog wal;

--- a/src/test/java/examples/TreeMap_Performance_Tunning.java
+++ b/src/test/java/examples/TreeMap_Performance_Tunning.java
@@ -35,7 +35,7 @@ import java.util.Random;
 public class TreeMap_Performance_Tunning {
 
 
-    static final int[] nodeSizes = {6, 18, 32, 64, 120};
+    private static final int[] nodeSizes = {6, 18, 32, 64, 120};
 
 
     public static void main(String[] args) {

--- a/src/test/java/org/mapdb/ExamplesTest.java
+++ b/src/test/java/org/mapdb/ExamplesTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 
 public class ExamplesTest {
 
-    static final String[] args= new String[0];
+    private static final String[] args= new String[0];
 
     @Test public void all_examples_test(){
         File f = new File("src/test/java/examples");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1873 - “static final arrays should be "private"”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1873.

Please let me know if you have any questions.

Christian Ivan