### PR TITLE
Code quality fix - Constructors should only call non-overridable methods

### DIFF
--- a/src/main/java/org/mapdb/DB.java
+++ b/src/main/java/org/mapdb/DB.java
@@ -291,7 +291,7 @@ public class DB implements Closeable {
      * @param obj object to get name for
      * @return name for this object, if it has name and was instanciated by this DB
      */
-    public String getNameForObject(Object obj) {
+    public final String getNameForObject(Object obj) {
         return namesLookup.get(new IdentityWrapper(obj));
     }
 
@@ -2710,7 +2710,7 @@ public class DB implements Closeable {
     /**
      * @return underlying engine which takes care of persistence for this DB.
      */
-    public Engine getEngine() {
+    public final Engine getEngine() {
         return engine;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1699 - “Constructors should only call non-overridable methods”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1699

Please let me know if you have any questions.

Christian Ivan