### PR TITLE
Quiet GC/leak warnings

### DIFF
--- a/release.gradle
+++ b/release.gradle
@@ -195,6 +195,7 @@ task(release_debug) << {
 
     ant.replace(file: destDir.path+'/src/main/java/org/mapdb/CC.java', token: 'boolean PARANOID = false;', value: 'boolean PARANOID = true;')
     ant.replace(file: destDir.path+'/src/main/java/org/mapdb/CC.java', token: 'boolean LOG_FINE = false;', value: 'boolean LOG_FINE = true;')
+    ant.replace(file: destDir.path+'/src/main/java/org/mapdb/CC.java', token: 'boolean CTORSTACKTRACE = false;', value: 'boolean CTORSTACKTRACE = true;')
     gitAndRelease(destDir)
 }
 

--- a/src/main/java/org/mapdb/CC.java
+++ b/src/main/java/org/mapdb/CC.java
@@ -46,6 +46,11 @@ interface CC {
      */
     boolean ASSERT = true;
 
+    /**
+     * Print stack traces for the creation of objects which later display issues.
+     */
+    boolean CTORSTACKTRACE = false;
+
     boolean PARANOID = false;
 
 

--- a/src/main/java/org/mapdb/Volume.java
+++ b/src/main/java/org/mapdb/Volume.java
@@ -2676,6 +2676,10 @@ public abstract class Volume implements Closeable{
                     }
                 }
             } catch (IOException e) {
+                // At this point, the caller will not be able to get a handle on this
+                // object and therefore the finalizer may incorrectly print that the
+                // object was unclosed on GC.
+                closed = true;
                 throw new DBException.VolumeIOError(e);
             }
         }

--- a/src/main/java/org/mapdb/Volume.java
+++ b/src/main/java/org/mapdb/Volume.java
@@ -158,16 +158,28 @@ public abstract class Volume implements Closeable{
     }
 
     //uncomment to get stack trace on Volume leak warning
-//    final private Throwable constructorStackTrace = new AssertionError();
+    final private Throwable constructorStackTrace;
+    {
+        if (CC.CTORSTACKTRACE) {
+            constructorStackTrace = new AssertionError();
+        } else {
+            constructorStackTrace = null;
+        }
+    }
 
     @Override protected void finalize(){
         if(CC.ASSERT){
             if(!closed
                     && !(this instanceof ByteArrayVol)
                     && !(this instanceof SingleByteArrayVol)){
-                LOG.log(Level.WARNING, "Open Volume was GCed, possible file handle leak."
-//                        ,constructorStackTrace
-                );
+                if (CC.CTORSTACKTRACE) {
+                    LOG.log(Level.WARNING,
+                        "Open Volume was GCed, possible file handle leak."
+                        ,constructorStackTrace);
+                } else {
+                    LOG.log(Level.WARNING,
+                        "Open Volume was GCed, possible file handle leak.");
+                }
             }
         }
     }


### PR DESCRIPTION
https://github.com/jankotek/mapdb/commit/b9e51e5a65cbdcad60c029072163b081d6cb39d1 silences the `Open Volume was GCed, possible file handle leak` message in the case that an `IOException` was thrown during construction. A more extensive change would be to catch `Throwable` and also set `closed` but I wasn't sure of the implications. The change is also applicable to the 3.0 series (`src/main/java/org/mapdb/volume/MappedFileVol.java`) but I haven't done any testing yet with 3.x.

The [other commit](https://github.com/jankotek/mapdb/commit/5fe2d69bab747b00a43dcf6feaa4244e76f98195) allows enabling the `constructorStackTrace` in `Volume.java` via `CC` but if that's not of interest, I'm happy to push force it away.