### PR TITLE
HTreeMap. Fix #583 (for branch release-1.0 )

### DIFF
--- a/src/main/java/org/mapdb/HTreeMap.java
+++ b/src/main/java/org/mapdb/HTreeMap.java
@@ -401,7 +401,7 @@ public class HTreeMap<K,V>   extends AbstractMap<K,V> implements ConcurrentMap<K
         }finally {
             lock.unlock();
         }
-        if(valueCreator==null){
+        if(valueCreator==null || ln!=null){
             if(ln==null)
                 return null;
             return ln.value;


### PR DESCRIPTION
HTreeMap: valueCreator was used, even if value existed. Fix #583 (for branch release-1.0 )

I'm using a version based on the branche 1.0, and found that this bug has been fixed. But I am using a library that uses an old version:

https://github.com/andsel/moquette

You could generate a SNAPSHOT. Please ?