### PR TITLE
Add serializers for java.util.(Date|Time|Timestamp)

### DIFF
--- a/src/main/java/org/mapdb/Serializer.java
+++ b/src/main/java/org/mapdb/Serializer.java
@@ -465,6 +465,12 @@ public interface Serializer<A /*extends Comparable<? super A>*/> extends Compara
     GroupSerializer<Class<?>> CLASS = new SerializerClass();
 
     GroupSerializer<Date> DATE = new SerializerDate();
+    
+    GroupSerializer<java.sql.Date> SQL_DATE = new SerializerSqlDate();
+    
+    GroupSerializer<java.sql.Time> SQL_TIME = new SerializerSqlTime();
+    
+    GroupSerializer<java.sql.Timestamp> SQL_TIMESTAMP = new SerializerSqlTimestamp();
 
     //    //this has to be lazily initialized due to circular dependencies
 //    static final  class __BasicInstance {

--- a/src/main/java/org/mapdb/serializer/SerializerSqlDate.java
+++ b/src/main/java/org/mapdb/serializer/SerializerSqlDate.java
@@ -1,0 +1,48 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.mapdb.serializer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.sql.Date;
+import org.mapdb.DataInput2;
+import org.mapdb.DataOutput2;
+import org.mapdb.serializer.SerializerEightByte;
+
+/**
+ *
+ * @author Per Minborg
+ */
+public class SerializerSqlDate extends SerializerEightByte<Date> {
+
+    @Override
+    public void serialize(DataOutput2 out, Date value) throws IOException {
+        out.writeLong(value.getTime());
+    }
+
+    @Override
+    public Date deserialize(DataInput2 in, int available) throws IOException {
+        return new Date(in.readLong());
+    }
+
+    @Override
+    protected Date unpack(long l) {
+        return new Date(l);
+    }
+
+    @Override
+    protected long pack(Date l) {
+        return l.getTime();
+    }
+
+    @Override
+    final public int valueArraySearch(Object keys, Date key) {
+        //TODO valueArraySearch versus comparator test
+        long time = key.getTime();
+        return Arrays.binarySearch((long[])keys, time);
+    }
+    
+}

--- a/src/main/java/org/mapdb/serializer/SerializerSqlTime.java
+++ b/src/main/java/org/mapdb/serializer/SerializerSqlTime.java
@@ -1,0 +1,48 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.mapdb.serializer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.sql.Time;
+import org.mapdb.DataInput2;
+import org.mapdb.DataOutput2;
+import org.mapdb.serializer.SerializerEightByte;
+
+/**
+ *
+ * @author Per Minborg
+ */
+public class SerializerSqlTime extends SerializerEightByte<Time> {
+
+    @Override
+    public void serialize(DataOutput2 out, Time value) throws IOException {
+        out.writeLong(value.getTime());
+    }
+
+    @Override
+    public Time deserialize(DataInput2 in, int available) throws IOException {
+        return new Time(in.readLong());
+    }
+
+    @Override
+    protected Time unpack(long l) {
+        return new Time(l);
+    }
+
+    @Override
+    protected long pack(Time l) {
+        return l.getTime();
+    }
+
+    @Override
+    final public int valueArraySearch(Object keys, Time key) {
+        //TODO valueArraySearch versus comparator test
+        long time = key.getTime();
+        return Arrays.binarySearch((long[])keys, time);
+    }
+    
+}

--- a/src/main/java/org/mapdb/serializer/SerializerSqlTimestamp.java
+++ b/src/main/java/org/mapdb/serializer/SerializerSqlTimestamp.java
@@ -1,0 +1,48 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.mapdb.serializer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.sql.Timestamp;
+import org.mapdb.DataInput2;
+import org.mapdb.DataOutput2;
+import org.mapdb.serializer.SerializerEightByte;
+
+/**
+ *
+ * @author Per Minborg
+ */
+public class SerializerSqlTimestamp extends SerializerEightByte<Timestamp> {
+
+    @Override
+    public void serialize(DataOutput2 out, Timestamp value) throws IOException {
+        out.writeLong(value.getTime());
+    }
+
+    @Override
+    public Timestamp deserialize(DataInput2 in, int available) throws IOException {
+        return new Timestamp(in.readLong());
+    }
+
+    @Override
+    protected Timestamp unpack(long l) {
+        return new Timestamp(l);
+    }
+
+    @Override
+    protected long pack(Timestamp l) {
+        return l.getTime();
+    }
+
+    @Override
+    final public int valueArraySearch(Object keys, Timestamp key) {
+        //TODO valueArraySearch versus comparator test
+        long time = key.getTime();
+        return Arrays.binarySearch((long[])keys, time);
+    }
+    
+}

--- a/src/main/java/org/mapdb/serializer/SerializerUtils.java
+++ b/src/main/java/org/mapdb/serializer/SerializerUtils.java
@@ -1,6 +1,5 @@
 package org.mapdb.serializer;
 
-import org.mapdb.Serializer;
 
 import java.util.HashMap;
 
@@ -16,50 +15,61 @@ import java.util.*;
  */
 public final class SerializerUtils {
 
-    private static Map<Class, Serializer> SERIALIZER_FOR_CLASS = new HashMap();
-
-    static {
-            SERIALIZER_FOR_CLASS.put(char.class, CHAR);
-            SERIALIZER_FOR_CLASS.put(Character.class, CHAR);
-            SERIALIZER_FOR_CLASS.put(String.class, STRING);
-            SERIALIZER_FOR_CLASS.put(long.class, LONG);
-            SERIALIZER_FOR_CLASS.put(Long.class, LONG);
-            SERIALIZER_FOR_CLASS.put(int.class, INTEGER);
-            SERIALIZER_FOR_CLASS.put(Integer.class, INTEGER);
-            SERIALIZER_FOR_CLASS.put(boolean.class, BOOLEAN);
-            SERIALIZER_FOR_CLASS.put(Boolean.class, BOOLEAN);
-            SERIALIZER_FOR_CLASS.put(byte[].class, BYTE_ARRAY);
-            SERIALIZER_FOR_CLASS.put(char[].class, CHAR_ARRAY);
-            SERIALIZER_FOR_CLASS.put(int[].class, INT_ARRAY);
-            SERIALIZER_FOR_CLASS.put(long[].class, LONG_ARRAY);
-            SERIALIZER_FOR_CLASS.put(double[].class, DOUBLE_ARRAY);
-            SERIALIZER_FOR_CLASS.put(UUID.class, UUID);
-            SERIALIZER_FOR_CLASS.put(byte.class, BYTE);
-            SERIALIZER_FOR_CLASS.put(Byte.class, BYTE);
-            SERIALIZER_FOR_CLASS.put(float.class, FLOAT);
-            SERIALIZER_FOR_CLASS.put(Float.class, FLOAT);
-            SERIALIZER_FOR_CLASS.put(double.class, DOUBLE);
-            SERIALIZER_FOR_CLASS.put(Double.class, DOUBLE);
-            SERIALIZER_FOR_CLASS.put(short.class, SHORT);
-            SERIALIZER_FOR_CLASS.put(Short.class, SHORT);
-            SERIALIZER_FOR_CLASS.put(short[].class, SHORT_ARRAY);
-            SERIALIZER_FOR_CLASS.put(float[].class, FLOAT_ARRAY);
-            SERIALIZER_FOR_CLASS.put(BigDecimal.class, BIG_DECIMAL);
-            SERIALIZER_FOR_CLASS.put(BigInteger.class, BIG_INTEGER);
-            SERIALIZER_FOR_CLASS.put(Class.class, CLASS);
-            SERIALIZER_FOR_CLASS.put(Date.class, DATE);
-
+    private static final Map<Class<?>, Serializer<?>> SERIALIZER_FOR_CLASS = new HashMap<>();
+    
+    static {       
+        put(char.class, CHAR);
+        put(Character.class, CHAR);
+        put(String.class, STRING);
+        put(long.class, LONG);
+        put(Long.class, LONG);
+        put(int.class, INTEGER);
+        put(Integer.class, INTEGER);
+        put(boolean.class, BOOLEAN);
+        put(Boolean.class, BOOLEAN);
+        put(byte[].class, BYTE_ARRAY);
+        put(char[].class, CHAR_ARRAY);
+        put(int[].class, INT_ARRAY);
+        put(long[].class, LONG_ARRAY);
+        put(double[].class, DOUBLE_ARRAY);
+        put(UUID.class, UUID);
+        put(byte.class, BYTE);
+        put(Byte.class, BYTE);
+        put(float.class, FLOAT);
+        put(Float.class, FLOAT);
+        put(double.class, DOUBLE);
+        put(Double.class, DOUBLE);
+        put(short.class, SHORT);
+        put(Short.class, SHORT);
+        put(short[].class, SHORT_ARRAY);
+        put(float[].class, FLOAT_ARRAY);
+        put(BigDecimal.class, BIG_DECIMAL);
+        put(BigInteger.class, BIG_INTEGER);
+        put(Class.class, CLASS);
+        put(Date.class, DATE);
+        put(java.sql.Date.class, SQL_DATE);
+        put(java.sql.Time.class, SQL_TIME);
+        put(java.sql.Timestamp.class, SQL_TIMESTAMP);
     }
+    
+    // Make sure we are type safe!
+    private static <T> void put(Class<? super T> clazz, Serializer<T> serializer) {
+        SERIALIZER_FOR_CLASS.put(clazz, serializer);
+    } 
+    
 
-
-    public static <R> Serializer<R> serializerForClass(Class<R> clazz){
-        return SERIALIZER_FOR_CLASS.get(clazz);
+    public static <R> Serializer<R> serializerForClass(Class<R> clazz) {
+        @SuppressWarnings("unchecked")
+        final Serializer<R> result = (Serializer<R>) SERIALIZER_FOR_CLASS.get(clazz);
+        return result;
     }
 
     public static int compareInt(int x, int y) {
         return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 
-
+    private SerializerUtils() {
+        throw new UnsupportedOperationException("Instance of utility class not allowed");
+    }
 
 }


### PR DESCRIPTION
Even though these classes implements Date it is useful to have separate
serializers for them. Also, cleanup of the SerailizerUtil class so it
is now type safe when adding new serializers and the map is final.
