### PR TITLE
Update DataIO.java

### DIFF
--- a/src/main/java/org/mapdb/DataIO.java
+++ b/src/main/java/org/mapdb/DataIO.java
@@ -15,16 +15,16 @@ public final class DataIO {
     /**
      * Unpack int value from the input stream.
      *
-     * @param is The input stream.
+     * @param in The input stream.
      * @return The long value.
      *
      * @throws java.io.IOException in case of IO error
      */
-    static public int unpackInt(DataInput is) throws IOException {
+    static public int unpackInt(DataInput in) throws IOException {
         int ret = 0;
         byte v;
         do{
-            v = is.readByte();
+            v = in.readByte();
             ret = (ret<<7 ) | (v & 0x7F);
         }while((v&0x80)==0);
 


### PR DESCRIPTION
The method's (unpackInt(DataInput is) ) parameter name is a naming convention smell. So it might be renamed as unpackInt(DataInput in).