### PR TITLE
Fix volume locking to timeout even if another JVM holds a lock

### DIFF
--- a/src/main/java/org/mapdb/DBException.kt
+++ b/src/main/java/org/mapdb/DBException.kt
@@ -36,7 +36,7 @@ open class DBException(message: String?, cause: Throwable?) : RuntimeException(m
 
     class PointerChecksumBroken():DataCorruption("Broken bit parity")
 
-    class FileLocked(path: Path, exception: Exception):
+    class FileLocked(path: Path, exception: Exception?):
             DBException("File is already opened and is locked: "+path, exception)
 
 

--- a/src/test/java/org/mapdb/JavaProcess.java
+++ b/src/test/java/org/mapdb/JavaProcess.java
@@ -1,0 +1,32 @@
+package org.mapdb;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public final class JavaProcess {
+
+    private JavaProcess() {}
+
+    public static Process exec(Class klass, String[] args) throws IOException,
+            InterruptedException {
+        String javaHome = System.getProperty("java.home");
+        String javaBin = javaHome +
+                File.separator + "bin" +
+                File.separator + "java";
+        String classpath = System.getProperty("java.class.path");
+        String className = klass.getName();
+        List<String> commandArgs = new ArrayList<>();
+        commandArgs.add(javaBin);
+        commandArgs.add("-cp");
+        commandArgs.add(classpath);
+        commandArgs.add(className);
+        commandArgs.addAll(Arrays.asList(args));
+
+        ProcessBuilder builder = new ProcessBuilder(commandArgs);
+
+        return builder.start();
+    }
+}

--- a/src/test/java/org/mapdb/TT.kt
+++ b/src/test/java/org/mapdb/TT.kt
@@ -156,7 +156,9 @@ object TT{
         return out.pos;
     }
 
-
+    fun <T : Any> forkJvm(clazz:Class<T>, vararg args : String): Process {
+        return JavaProcess.exec(clazz, args)
+    }
 
     fun fork(count:Int=1, body:(i:Int)->Unit){
         val finish = async(count=count, body=body)


### PR DESCRIPTION
If a different JVM held a lock on the volume file then locking would wait indefinitely regardless of the set `fileLockWait`. This commit adds a test for this case and modifies locking to use `tryLock()`.

Fixes #780 