### PR TITLE
Add a classloader parameter to SerializerJava

### DIFF
--- a/src/main/java/org/mapdb/serializer/SerializerJava.java
+++ b/src/main/java/org/mapdb/serializer/SerializerJava.java
@@ -3,17 +3,60 @@ package org.mapdb.serializer;
 import org.mapdb.CC;
 import org.mapdb.DataInput2;
 import org.mapdb.DataOutput2;
-import org.mapdb.Serializer;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 import java.io.OutputStream;
 
 /**
  * Created by jan on 2/28/16.
  */
 public class SerializerJava extends GroupSerializerObjectArray {
+
+    protected final ClassLoader classLoader;
+
+    public SerializerJava(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    public SerializerJava(){
+        this(Thread.currentThread().getContextClassLoader());
+    }
+
+    /**
+     * This subclass of ObjectInputStream delegates loading of classes to
+     * an existing ClassLoader.
+     */
+
+    class ObjectInputStreamWithLoader extends ObjectInputStream
+    {
+        /**
+         * Loader must be non-null;
+         */
+
+        public ObjectInputStreamWithLoader(InputStream in)
+            throws IOException {
+            super(in);
+        }
+
+        /**
+         * Use the given ClassLoader rather than using the system class
+         */
+        @SuppressWarnings("rawtypes")
+        protected Class resolveClass(ObjectStreamClass desc)
+            throws IOException, ClassNotFoundException {
+            String name = desc.getName();
+            try {
+                return Class.forName(name, false, classLoader);
+            } catch (ClassNotFoundException ex) {
+                return super.resolveClass(desc);
+            }
+        }
+    }
+
     @Override
     public void serialize(DataOutput2 out, Object value) throws IOException {
         ObjectOutputStream out2 = new ObjectOutputStream((OutputStream) out);
@@ -24,7 +67,7 @@ public class SerializerJava extends GroupSerializerObjectArray {
     @Override
     public Object deserialize(DataInput2 in, int available) throws IOException {
         try {
-            ObjectInputStream in2 = new ObjectInputStream(new DataInput2.DataInputToStream(in));
+            ObjectInputStream in2 = new ObjectInputStreamWithLoader(new DataInput2.DataInputToStream(in));
             return in2.readObject();
         } catch (ClassNotFoundException e) {
             throw new IOException(e);
@@ -34,7 +77,7 @@ public class SerializerJava extends GroupSerializerObjectArray {
     @Override
     public Object[] valueArrayDeserialize(DataInput2 in, int size) throws IOException {
         try {
-            ObjectInputStream in2 = new ObjectInputStream(new DataInput2.DataInputToStream(in));
+            ObjectInputStream in2 = new ObjectInputStreamWithLoader(new DataInput2.DataInputToStream(in));
             Object ret =  in2.readObject();
             if(CC.PARANOID && size!=valueArraySize(ret))
                 throw new AssertionError();


### PR DESCRIPTION
**MapDB version 3.0.7**

Let's say you are using MapDB from a parent classloader.... but you are actually creating and running your MapDB from a separate custom classloader.

The `Serializer.JAVA` will give you class not found errors because it uses `java.io.ObjectInputStream#resolveClass` which will always use `sun.misc.VM.latestUserDefinedLoader()`

We need to allow a custom classloader parameter to be added to the java serializer

Usage example in my case:

```
private static SerializerJava SERIALIZER_JAVA = new SerializerJava(SiteLink.class.getClassLoader());
private ConcurrentMap<String, SiteLink> prefetchIndexMap = db.hashMap("prefetchIndexMap", Serializer.STRING, SERIALIZER_JAVA).createOrOpen();
```

I'm not sure if this is really related to https://github.com/jankotek/mapdb/issues/740 which uses a classloader variable in the DBMaker. 