### PR TITLE
Fix support cleaner hack java11

### DIFF
--- a/src/main/java/org/mapdb/IndexTreeLongLongMap.kt
+++ b/src/main/java/org/mapdb/IndexTreeLongLongMap.kt
@@ -53,6 +53,9 @@ public class IndexTreeLongLongMap(
     val levels:Int,
     val collapseOnRemove:Boolean
 ): AbstractLongIterable(), MutableLongLongMap {
+    override fun updateValues(p0: LongLongToLongFunction?) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
 
 
     companion object{

--- a/src/main/java/org/mapdb/IndexTreeLongLongMap.kt
+++ b/src/main/java/org/mapdb/IndexTreeLongLongMap.kt
@@ -793,9 +793,11 @@ public class IndexTreeLongLongMap(
         }
         return result
     }
-
+    /*
+    * Module would not compiled without adding implementing this method
+    * */
     override fun updateValues(p0: LongLongToLongFunction?) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+
     }
 
 }

--- a/src/main/java/org/mapdb/IndexTreeLongLongMap.kt
+++ b/src/main/java/org/mapdb/IndexTreeLongLongMap.kt
@@ -53,9 +53,6 @@ public class IndexTreeLongLongMap(
     val levels:Int,
     val collapseOnRemove:Boolean
 ): AbstractLongIterable(), MutableLongLongMap {
-    override fun updateValues(p0: LongLongToLongFunction?) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
 
 
     companion object{
@@ -795,6 +792,10 @@ public class IndexTreeLongLongMap(
             }
         }
         return result
+    }
+
+    override fun updateValues(p0: LongLongToLongFunction?) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
 }

--- a/src/main/java/org/mapdb/IndexTreeLongLongMap.kt
+++ b/src/main/java/org/mapdb/IndexTreeLongLongMap.kt
@@ -794,10 +794,12 @@ public class IndexTreeLongLongMap(
         return result
     }
     /*
-    * Module would not compiled without adding implementing this method
+    * This method was introduced in Eclipse Collections 10.0.0.M3
+    * Module would not compile without implementing this method
+    * pom.xml uses an open ended version, thats why Maven builds using latest version of Eclipse Collections.
     * */
     override fun updateValues(p0: LongLongToLongFunction?) {
-
+        throw UnsupportedOperationException("UpdateValues() hasn't been implemented yet");
     }
 
 }

--- a/src/main/java/org/mapdb/serializer/SerializerByteArrayDelta2.java
+++ b/src/main/java/org/mapdb/serializer/SerializerByteArrayDelta2.java
@@ -6,7 +6,7 @@ import org.mapdb.DataIO;
 import org.mapdb.DataInput2;
 import org.mapdb.DataOutput2;
 import org.mapdb.Serializer;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+//import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/src/main/java/org/mapdb/serializer/SerializerByteArrayDelta2.java
+++ b/src/main/java/org/mapdb/serializer/SerializerByteArrayDelta2.java
@@ -6,7 +6,6 @@ import org.mapdb.DataIO;
 import org.mapdb.DataInput2;
 import org.mapdb.DataOutput2;
 import org.mapdb.Serializer;
-//import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/src/main/java/org/mapdb/volume/ByteBufferVol.java
+++ b/src/main/java/org/mapdb/volume/ByteBufferVol.java
@@ -3,24 +3,12 @@ package org.mapdb.volume;
 import org.mapdb.CC;
 import org.mapdb.DBException;
 import org.mapdb.DataInput2;
-/*import sun.misc.Cleaner;
-import sun.nio.ch.DirectBuffer;*/
+import org.mapdb.volume.CleanerUtil;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.util.concurrent.locks.ReentrantLock;
-
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import static java.lang.invoke.MethodHandles.constant;
-import static java.lang.invoke.MethodHandles.dropArguments;
-import static java.lang.invoke.MethodHandles.filterReturnValue;
-import static java.lang.invoke.MethodHandles.guardWithTest;
-import static java.lang.invoke.MethodHandles.lookup;
-import static java.lang.invoke.MethodType.methodType;
 
 /**
  * Abstract Volume over bunch of ByteBuffers
@@ -38,9 +26,6 @@ abstract public class ByteBufferVol extends Volume {
 
     protected volatile ByteBuffer[] slices = new ByteBuffer[0];
     protected final boolean readOnly;
-
-    // null if unmap is not supported
-    private static final MethodHandle UNMAP;
 
     protected ByteBufferVol(boolean readOnly, int sliceShift, boolean cleanerHackEnabled) {
         this.readOnly = readOnly;
@@ -341,99 +326,23 @@ abstract public class ByteBufferVol extends Volume {
      * Any error is silently ignored (for example SUN API does not exist on Android).
      */
     protected static boolean unmap(MappedByteBuffer b){
-        if (!b.isDirect())
-            return false;
-        if (UNMAP == null)
-            return false;
-
-        try {
-            UNMAP.invokeExact((ByteBuffer) b);
-            return true;
-        } catch (Throwable throwable) {
-            return false;
-        }
-    }
-
-    private static MethodHandle lookupUnmapMethodHandle()
-            throws NoSuchMethodException, IllegalAccessException, ClassNotFoundException {
-        final MethodHandles.Lookup lookup = MethodHandles.lookup();
-        try {
+        if (CleanerUtil.UNMAP_SUPPORTED) {
             try {
-                // *** sun.misc.Unsafe unmapping (Java 9+) ***
-                final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
-                // first check if Unsafe has the right method, otherwise we can
-                // give up without doing any security critical stuff:
-                final MethodHandle unmapper = lookup.findVirtual(unsafeClass,
-                        "invokeCleaner", methodType(void.class, ByteBuffer.class));
-                // fetch the unsafe instance and bind it to the virtual MH:
-                final Field f = unsafeClass.getDeclaredField("theUnsafe");
-                f.setAccessible(true);
-                final Object theUnsafe = f.get(null);
-                return unmapper.bindTo(theUnsafe);
-            } catch (SecurityException se) {
-                // rethrow to report errors correctly (we need to catch it here,
-                // as we also catch RuntimeException below!):
-                throw se;
-            } catch (ReflectiveOperationException | RuntimeException e) {
-                // *** sun.misc.Cleaner unmapping (Java 8) ***
-                final Class<?> directBufferClass =
-                        Class.forName("java.nio.DirectByteBuffer");
-
-                final Method m = directBufferClass.getMethod("cleaner");
-                m.setAccessible(true);
-                final MethodHandle directBufferCleanerMethod = lookup.unreflect(m);
-                final Class<?> cleanerClass =
-                        directBufferCleanerMethod.type().returnType();
-                final MethodHandle cleanMethod = lookup.findVirtual(
-                        cleanerClass, "clean", methodType(void.class));
-                final MethodHandle nonNullTest = lookup.findStatic(ByteBufferVol.class,
-                        "nonNull", methodType(boolean.class, Object.class))
-                        .asType(methodType(boolean.class, cleanerClass));
-                final MethodHandle noop = dropArguments(
-                        constant(Void.class, null).asType(methodType(void.class)),
-                        0, cleanerClass);
-                final MethodHandle unmapper = filterReturnValue(
-                        directBufferCleanerMethod,
-                        guardWithTest(nonNullTest, cleanMethod, noop))
-                        .asType(methodType(void.class, ByteBuffer.class));
-                return unmapper;
+                CleanerUtil.freeBuffer((ByteBuffer) b);
+                return true;
+            } catch (IOException e) {
+                LOG.warning("Failed to free the buffer");
             }
-        } catch (SecurityException se) {
-            throw se;
-
-        } catch (ReflectiveOperationException | RuntimeException e) {
-            throw e;
-        }
-    }
-
-    static {
-        Object unmap = null;
-        try {
-            unmap = lookupUnmapMethodHandle();
-        } catch (RuntimeException e) {
-            LOG.warning("mmap file unmap hack not supported, mmap files will not be closed, sun.nio.ch.DirectBuffer not found");
-        }
-        catch (NoSuchMethodException e) {
-            LOG.warning("Method not found while applying reflection to invoke a cleaner function");
-        }
-        catch (IllegalAccessException e) {
-            LOG.warning("IllegalAccessException while applying reflection to invoke a cleaner function");
-        }
-        catch (ClassNotFoundException e) {
-            LOG.warning("Class not found while applying reflection to invoke a cleaner function");
-        }
-    if (unmap != null) {
-            UNMAP = (MethodHandle) unmap;
         } else {
-            UNMAP = null;
+            LOG.warning(CleanerUtil.UNMAP_NOT_SUPPORTED_REASON);
         }
+        return false;
     }
+
+
     // Workaround for https://github.com/jankotek/MapDB/issues/326
     // File locking after .close() on Windows.
     static boolean windowsWorkaround = System.getProperty("os.name").toLowerCase().startsWith("win");
 
-    private static boolean nonNull(Object o) {
-        return o != null;
-    }
 
 }

--- a/src/main/java/org/mapdb/volume/ByteBufferVol.java
+++ b/src/main/java/org/mapdb/volume/ByteBufferVol.java
@@ -331,7 +331,7 @@ abstract public class ByteBufferVol extends Volume {
                 CleanerUtil.freeBuffer((ByteBuffer) b);
                 return true;
             } catch (IOException e) {
-                LOG.warning("Failed to free the buffer");
+                LOG.warning("Failed to free the buffer. " + e);
             }
         } else {
             LOG.warning(CleanerUtil.UNMAP_NOT_SUPPORTED_REASON);

--- a/src/main/java/org/mapdb/volume/CleanerUtil.java
+++ b/src/main/java/org/mapdb/volume/CleanerUtil.java
@@ -37,7 +37,9 @@ import static java.lang.invoke.MethodType.methodType;
  * sun.misc.Unsafe#invokeCleaner(ByteBuffer) is the replacement.
  * This class is a hack to use sun.misc.Cleaner in Java 8 and
  * use the replacement in Java 9+.
- * This implementation is inspired by LUCENE-6989.
+ * This implementation is based on Hadoop class
+ * hadoop/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CleanerUtil.java
+ * Some adaptations have been done to handle the attachment() of the byte buffer (explained in Bug #776)
  */
 public final class CleanerUtil {
 
@@ -135,7 +137,7 @@ public final class CleanerUtil {
             }
         } catch (SecurityException se) {
             return "Unmapping is not supported, because not all required " +
-                    "permissions are given to the Hadoop JAR file: " + se +
+                    "permissions are given to the MapDB JAR file: " + se +
                     " [Please grant at least the following permissions: " +
                     "RuntimePermission(\"accessClassInPackage.sun.misc\") " +
                     " and ReflectPermission(\"suppressAccessChecks\")]";
@@ -154,7 +156,10 @@ public final class CleanerUtil {
 
             try {
                 CLEANER.invokeExact(buffer);
-                // Handling attachment of the ByteBuffer object
+                /*
+                * Handling attachment of the ByteBuffer object
+                * Refer to https://github.com/jankotek/mapdb/issues/776 for details
+                * */
                 if (JAVA8_OR_LESS) {
                     final MethodHandles.Lookup lookup = MethodHandles.lookup();
                     final Class<?> directBufferClass =

--- a/src/main/java/org/mapdb/volume/CleanerUtil.java
+++ b/src/main/java/org/mapdb/volume/CleanerUtil.java
@@ -38,7 +38,7 @@ import static java.lang.invoke.MethodType.methodType;
  * This class is a hack to use sun.misc.Cleaner in Java 8 and
  * use the replacement in Java 9+.
  * This implementation is based on Hadoop class
- * hadoop/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CleanerUtil.java
+ * https://github.com/apache/hadoop/blob/5d084d7eca32cfa647a78ff6ed3c378659f5b186/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/CleanerUtil.java
  * Some adaptations have been done to handle the attachment() of the byte buffer (explained in Bug #776)
  */
 public final class CleanerUtil {

--- a/src/main/java/org/mapdb/volume/CleanerUtil.java
+++ b/src/main/java/org/mapdb/volume/CleanerUtil.java
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mapdb.volume;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.util.Objects;
+
+import static java.lang.invoke.MethodHandles.constant;
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.filterReturnValue;
+import static java.lang.invoke.MethodHandles.guardWithTest;
+import static java.lang.invoke.MethodType.methodType;
+
+/**
+ * sun.misc.Cleaner has moved in OpenJDK 9 and
+ * sun.misc.Unsafe#invokeCleaner(ByteBuffer) is the replacement.
+ * This class is a hack to use sun.misc.Cleaner in Java 8 and
+ * use the replacement in Java 9+.
+ * This implementation is inspired by LUCENE-6989.
+ */
+public final class CleanerUtil {
+
+    // Prevent instantiation
+    private CleanerUtil(){}
+
+    /**
+     * <code>true</code>, if this platform supports unmapping mmapped files.
+     */
+    public static final boolean UNMAP_SUPPORTED;
+
+    /**
+     * if {@link #UNMAP_SUPPORTED} is {@code false}, this contains the reason
+     * why unmapping is not supported.
+     */
+    public static final String UNMAP_NOT_SUPPORTED_REASON;
+
+    public static boolean JAVA8_OR_LESS;
+    private static final MethodHandle CLEANER;
+
+
+    static {
+        Object hack = unmapHackImpl();
+        if (hack instanceof MethodHandle) {
+            CLEANER = (MethodHandle) unmapHackImpl();
+            UNMAP_SUPPORTED = true;
+            UNMAP_NOT_SUPPORTED_REASON = null;
+        } else {
+            CLEANER = null;
+            UNMAP_SUPPORTED = false;
+            UNMAP_NOT_SUPPORTED_REASON = hack.toString();
+        }
+    }
+
+    private static Object unmapHackImpl() {
+        final MethodHandles.Lookup lookup = MethodHandles.lookup();
+        try {
+            try {
+                // *** sun.misc.Unsafe unmapping (Java 9+) ***
+                final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+                // first check if Unsafe has the right method, otherwise we can
+                // give up without doing any security critical stuff:
+                final MethodHandle unmapper = lookup.findVirtual(unsafeClass,
+                        "invokeCleaner", methodType(void.class, ByteBuffer.class));
+                // fetch the unsafe instance and bind it to the virtual MH:
+                final Field f = unsafeClass.getDeclaredField("theUnsafe");
+                f.setAccessible(true);
+                final Object theUnsafe = f.get(null);
+                return unmapper.bindTo(theUnsafe);
+            } catch (SecurityException se) {
+                // rethrow to report errors correctly (we need to catch it here,
+                // as we also catch RuntimeException below!):
+                throw se;
+            } catch (ReflectiveOperationException | RuntimeException e) {
+                // *** sun.misc.Cleaner unmapping (Java 8) ***
+                final Class<?> directBufferClass =
+                        Class.forName("java.nio.DirectByteBuffer");
+
+                final Method m = directBufferClass.getMethod("cleaner");
+                m.setAccessible(true);
+                final MethodHandle directBufferCleanerMethod = lookup.unreflect(m);
+                final Class<?> cleanerClass =
+                        directBufferCleanerMethod.type().returnType();
+
+                /*
+                 * "Compile" a MethodHandle that basically is equivalent
+                 * to the following code:
+                 *
+                 * void unmapper(ByteBuffer byteBuffer) {
+                 *   sun.misc.Cleaner cleaner =
+                 *       ((java.nio.DirectByteBuffer) byteBuffer).cleaner();
+                 *   if (Objects.nonNull(cleaner)) {
+                 *     cleaner.clean();
+                 *   } else {
+                 *     // the noop is needed because MethodHandles#guardWithTest
+                 *     // always needs ELSE
+                 *     noop(cleaner);
+                 *   }
+                 * }
+                 */
+                final MethodHandle cleanMethod = lookup.findVirtual(
+                        cleanerClass, "clean", methodType(void.class));
+                final MethodHandle nonNullTest = lookup.findStatic(Objects.class,
+                        "nonNull", methodType(boolean.class, Object.class))
+                        .asType(methodType(boolean.class, cleanerClass));
+                final MethodHandle noop = dropArguments(
+                        constant(Void.class, null).asType(methodType(void.class)),
+                        0, cleanerClass);
+                final MethodHandle unmapper = filterReturnValue(
+                        directBufferCleanerMethod,
+                        guardWithTest(nonNullTest, cleanMethod, noop))
+                        .asType(methodType(void.class, ByteBuffer.class));
+                JAVA8_OR_LESS = true;
+                return unmapper;
+            }
+        } catch (SecurityException se) {
+            return "Unmapping is not supported, because not all required " +
+                    "permissions are given to the Hadoop JAR file: " + se +
+                    " [Please grant at least the following permissions: " +
+                    "RuntimePermission(\"accessClassInPackage.sun.misc\") " +
+                    " and ReflectPermission(\"suppressAccessChecks\")]";
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            return "Unmapping is not supported on this platform, " +
+                    "because internal Java APIs are not compatible with " +
+                    "this Hadoop version: " + e;
+        }
+    }
+
+    public static boolean freeBuffer (ByteBuffer buffer) throws IOException {
+            if (!buffer.isDirect() && UNMAP_SUPPORTED) {
+                throw new IllegalArgumentException(
+                        "unmapping only works with direct buffers");
+            }
+
+            try {
+                CLEANER.invokeExact(buffer);
+                // Handling attachment of the ByteBuffer object
+                if (JAVA8_OR_LESS) {
+                    final MethodHandles.Lookup lookup = MethodHandles.lookup();
+                    final Class<?> directBufferClass =
+                            Class.forName("java.nio.DirectByteBuffer");
+                    Object bb = directBufferClass.cast(buffer);
+                    final Method m = directBufferClass.getMethod("attachment");
+                    m.setAccessible(true);
+                    final MethodHandle directBufferAttachmentMethod = lookup.unreflect(m);
+                    Object attachment = (Object) directBufferAttachmentMethod.invoke(bb);
+                    if(attachment != null)
+                        return freeBuffer((MappedByteBuffer) attachment);
+                }
+                return true;
+            } catch (Throwable e) {
+                throw new IOException(e);
+            }
+
+    }
+}

--- a/src/test/java/org/mapdb/jsr166Tests/ArrayDequeTest.java
+++ b/src/test/java/org/mapdb/jsr166Tests/ArrayDequeTest.java
@@ -718,7 +718,7 @@ public class ArrayDequeTest extends JSR166TestCase {
         ArrayDeque l = new ArrayDeque();
         l.add(new Object());
         try {
-            l.toArray(null);
+            l.toArray((Object[]) null);
             shouldThrow();
         } catch (NullPointerException success) {}
     }

--- a/src/test/java/org/mapdb/jsr166Tests/BlockingQueueTest.java
+++ b/src/test/java/org/mapdb/jsr166Tests/BlockingQueueTest.java
@@ -133,7 +133,7 @@ public abstract class BlockingQueueTest extends JSR166TestCase {
     public void testToArray_NullArray() {
         final Collection q = emptyCollection();
         try {
-            q.toArray(null);
+            q.toArray((Object[]) null);
             shouldThrow();
         } catch (NullPointerException success) {}
     }

--- a/src/test/java/org/mapdb/jsr166Tests/ConcurrentLinkedDequeTest.java
+++ b/src/test/java/org/mapdb/jsr166Tests/ConcurrentLinkedDequeTest.java
@@ -673,7 +673,7 @@ public class ConcurrentLinkedDequeTest extends JSR166TestCase {
     public void testToArray_NullArg() {
         ConcurrentLinkedDeque q = populatedDeque(SIZE);
         try {
-            q.toArray(null);
+            q.toArray((Object[]) null);
             shouldThrow();
         } catch (NullPointerException success) {}
     }

--- a/src/test/java/org/mapdb/jsr166Tests/ConcurrentLinkedQueueTest.java
+++ b/src/test/java/org/mapdb/jsr166Tests/ConcurrentLinkedQueueTest.java
@@ -404,7 +404,7 @@ public class ConcurrentLinkedQueueTest extends JSR166TestCase {
     public void testToArray_NullArg() {
         ConcurrentLinkedQueue q = populatedQueue(SIZE);
         try {
-            q.toArray(null);
+            q.toArray((Object[]) null);
             shouldThrow();
         } catch (NullPointerException success) {}
     }

--- a/src/test/java/org/mapdb/jsr166Tests/LinkedListTest.java
+++ b/src/test/java/org/mapdb/jsr166Tests/LinkedListTest.java
@@ -359,7 +359,7 @@ public class LinkedListTest extends JSR166TestCase {
         LinkedList l = new LinkedList();
         l.add(new Object());
         try {
-            l.toArray(null);
+            l.toArray((Object[]) null);
             shouldThrow();
         } catch (NullPointerException success) {}
     }

--- a/src/test/java/org/mapdb/volume/VolumeTest.kt
+++ b/src/test/java/org/mapdb/volume/VolumeTest.kt
@@ -174,7 +174,9 @@ class VolumeTest {
         assertEquals(112314123, v.getLong(0))
         v.close()
     }
-
+    /*
+    * single_mmap_grow_with_cleaner_hack is the same test as single_mmap_grow but with Cleaner Hack Enabled
+    * */
     @org.junit.Test @Throws(IOException::class)
     fun single_mmap_grow_with_cleaner_hack() {
         val f = File.createTempFile("mapdbTest", "mapdb")

--- a/src/test/java/org/mapdb/volume/VolumeTest.kt
+++ b/src/test/java/org/mapdb/volume/VolumeTest.kt
@@ -175,6 +175,20 @@ class VolumeTest {
         v.close()
     }
 
+    @org.junit.Test @Throws(IOException::class)
+    fun single_mmap_grow_with_cleaner_hack() {
+        val f = File.createTempFile("mapdbTest", "mapdb")
+        val raf = RandomAccessFile(f, "rw")
+        raf.seek(0)
+        raf.writeLong(112314123)
+        raf.close()
+        assertEquals(8, f.length())
+
+        val v = MappedFileVolSingle(f, false, 0L, 1000, true)
+        assertEquals(1000, f.length())
+        assertEquals(112314123, v.getLong(0))
+        v.close()
+    }
     @org.junit.Test
     @Throws(IOException::class)
     fun lock_double_open() {


### PR DESCRIPTION
- Added volume/CleanerUtil.java class to handle reflection code for invoking cleaner mapped memory buffer cleaner methods.
- IndexTreeLongLongMap.kt - added updateValues() method unimplemented because this has been introduced in the latest Eclipse Collections 10.0.0.M3. The project automatically uses the latest version of the dependency because of the way version has been defined in pom.xml.
<ec.version>[7.0.0,)</ec.version>
- Added a test to check the unmap() behaviour when cleanerHack is enabled
