### PR TITLE
Update StoreDirect.kt

### DIFF
--- a/src/main/java/org/mapdb/StoreDirect.kt
+++ b/src/main/java/org/mapdb/StoreDirect.kt
@@ -517,9 +517,8 @@ class StoreDirect(
     }
 
     override fun <R> get(recid: Long, serializer: Serializer<R>): R? {
-        assertNotClosed()
-
         Utils.lockRead(locks[recidToSegment(recid)]) {
+            assertNotClosed()
             val indexVal = getIndexVal(recid);
 
             if (indexValFlagLinked(indexVal)) {


### PR DESCRIPTION
There is a race, when Store is closed, but there are still iterators somewhere, which may use it.
In the concurrent environment, `get()` call can pass `assertNotClosed` assertion, but acquire the lock after `Store::close` completed. 

Probably linked to https://github.com/jankotek/mapdb/issues/892 as well, if there is a scenario with concurrent `close` and `get`.

Note: this will still lead to exception, however it will be an `IllegalAccessError`, rather then `NullPointerException`