### PR TITLE
Add Java 9 / Jigsaw auto-manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,13 @@ dokka{
 }
 apply plugin: "kotlin"
 
-
+jar {
+    manifest {
+        attributes(
+            'Automatic-Module-Name' : 'mapdb'
+        )
+    }
+}
 compileKotlin {
     kotlinOptions {
         jvmTarget = '1.8'


### PR DESCRIPTION
Adding the manifest entry will ensure consistent use for java 9 and above when used as module