### PR TITLE
Move from `net.jpountz.lz4:lz4` to `org.lz4:lz4-java`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    compile 'net.jpountz.lz4:lz4:1.3.0'
-    //TODO is there better version?
+    compile 'org.lz4:lz4-java:1.7.1'
 
     testCompile("io.kotlintest:kotlintest-runner-junit5:3.4.2")
     testCompile("org.junit.vintage:junit-vintage-engine:$junit_version")


### PR DESCRIPTION
The former appears to have migrated to the latter, as per the advisory
notice on <https://mvnrepository.com/artifact/net.jpountz.lz4/lz4>.
Another hint: `net.jpountz.lz4` hasn't been updated since 2014 while
`org.lz4` is still seeing recent updates.