### PR TITLE
Remove usage of Eclipse Collections (close #952)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ buildscript {
 
     ext.kotlin_version = '1.4.10'
     ext.junit_version = '5.7.0'
-    ext.ec_version = '10.4.0'
     ext.guava_version = '28.2-jre'
 
     repositories {
@@ -48,9 +47,6 @@ test{
 }
 
 dependencies {
-    compile "org.eclipse.collections:eclipse-collections-api:$ec_version"
-    compile "org.eclipse.collections:eclipse-collections:$ec_version"
-
     compile "com.google.guava:guava:$guava_version"
 
     compile group: 'org.jetbrains', name: 'annotations', version: '20.1.0'

--- a/src/main/java/org/mapdb/store/FileHeapBufStore.java
+++ b/src/main/java/org/mapdb/store/FileHeapBufStore.java
@@ -57,7 +57,7 @@ public class FileHeapBufStore extends HeapBufStore{
         try( DataOutputStream out = new DataOutputStream(new FileOutputStream(file))) {
             IO.writeLong(out, records.size());
 
-            records.forEachKeyValue((recid, buf) ->{
+            records.forEach((recid, buf) ->{
                 try {
                     IO.writeLong(out, recid);
                     int size = buf==PREALLOC_RECORD? -1 : buf.length;
@@ -85,8 +85,6 @@ public class FileHeapBufStore extends HeapBufStore{
     private void clear() {
         //-AWLOCK
         freeRecids.clear();
-        freeRecids.trimToSize();
         records.clear();
-        records.compact();
     }
 }

--- a/src/main/java/org/mapdb/store/HeapBufStore.java
+++ b/src/main/java/org/mapdb/store/HeapBufStore.java
@@ -1,7 +1,10 @@
 package org.mapdb.store;
 
-import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList;
-import org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.jetbrains.annotations.NotNull;
 import org.mapdb.DBException;
 import org.mapdb.io.DataInput2ByteArray;
@@ -14,9 +17,9 @@ public class HeapBufStore implements Store {
 
     //-newRWLOCK
 
-    protected final LongObjectHashMap<byte[]> records = LongObjectHashMap.newMap();
+    protected final Map<Long,byte[]> records = new HashMap<>();
 
-    protected final LongArrayList freeRecids = new LongArrayList();
+    protected final List<Long> freeRecids = new ArrayList<>();
 
 
     protected long maxRecid = 0L;
@@ -46,7 +49,7 @@ public class HeapBufStore implements Store {
         long recid =
                 freeRecids.isEmpty()?
                     ++maxRecid :
-                    freeRecids.removeAtIndex(freeRecids.size()-1);
+                    freeRecids.remove(freeRecids.size()-1);
         records.put(recid, PREALLOC_RECORD);
         return recid;
     }
@@ -145,7 +148,7 @@ public class HeapBufStore implements Store {
 
     protected void delete2(long recid) {
         //-ARLOCKED
-        byte[] buf = records.removeKey(recid);
+        byte[] buf = records.remove(recid);
         if(buf == null)
             throw new DBException.RecordNotFound();
         if(buf == PREALLOC_RECORD) {
@@ -182,7 +185,7 @@ public class HeapBufStore implements Store {
     @Override
     public void getAll(GetAllCallback callback) {
         //--RLOCK
-        records.forEachKeyValue(
+        records.forEach(
                 (recid, buf) -> {
                     if (buf != PREALLOC_RECORD)
                         callback.takeOne(recid, buf);
@@ -215,8 +218,6 @@ public class HeapBufStore implements Store {
     @Override
     public void compact() {
         //-WLOCK
-        records.compact();
-        freeRecids.trimToSize();
         //-WUNLOCK
     }
 

--- a/src/test/java/org/mapdb/store/StoreTest.kt
+++ b/src/test/java/org/mapdb/store/StoreTest.kt
@@ -1,8 +1,6 @@
 package org.mapdb.store
 
 import io.kotlintest.shouldBe
-import org.eclipse.collections.impl.list.mutable.primitive.LongArrayList
-import org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap
 import org.junit.Assert.*
 import org.junit.Test
 import org.mapdb.DBException
@@ -466,7 +464,7 @@ abstract class StoreTest {
         val s = openStore()
         val random = Random(1);
         val endTime = TT.nowPlusMinutes(10.0)
-        val ref = LongObjectHashMap<ByteArray>()
+        val ref = HashMap<Long,ByteArray>()
         //TODO params could cause OOEM if too big. Make another case of tests with extremely large memory, or disk space
         val maxRecSize = 1000
         val maxSize = 66000 * 3
@@ -481,7 +479,7 @@ abstract class StoreTest {
         s.verify()
 
         while(endTime>System.currentTimeMillis()){
-            ref.forEachKeyValue { recid, record ->
+            ref.forEach { recid, record ->
                 val old = s.get(recid, Serializers.BYTE_ARRAY_NOSIZE)
                 assertTrue(Arrays.equals(record, old))
 
@@ -536,7 +534,7 @@ abstract class StoreTest {
             val store = openStore()
             val maxCount = 1 + maxStoreSize / size;
             //insert recids
-            val recids = LongArrayList()
+            val recids = ArrayList<Long>()
             for (i in 0..maxCount) {
                 val r = TT.randomByteArray(size, seed = i)
                 val recid = store.put(r, Serializers.BYTE_ARRAY_NOSIZE)
@@ -545,7 +543,7 @@ abstract class StoreTest {
 
             fun verify() {
                 //verify recids
-                recids.forEachWithIndex { recid, i ->
+                recids.forEachIndexed { i, recid ->
                     val r = store.get(recid, Serializers.BYTE_ARRAY_NOSIZE)
                     assertTrue(Arrays.equals(r, TT.randomByteArray(size, seed=i)))
                 }


### PR DESCRIPTION
Replace the usage of classes from Eclipse Collections with Java SE ones.